### PR TITLE
Refactor quote charges into configurable line items catalogue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Each endpoint in `Pages/Api/` follows the same pattern: authenticate to CERM via
 ## External Dependencies
 
 - **CERM APIs** — OAuth token endpoint + parameter/calculation endpoints (configured in `Cerm:*` settings)
-- **SQL Server** — CERM database via EF Core (connection string: `CermDbConnection`)
+- **SQL Server** — CERM database via EF Core (connection string: `CermDatabase`)
 - **Ollama** (optional) — local LLM for chat feature at `localhost:11434`
 - **SMTP** (optional) — for email notifications
 

--- a/Configuration/LineItemOptions.cs
+++ b/Configuration/LineItemOptions.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WiseLabels.Configuration
 {
@@ -29,12 +29,18 @@ namespace WiseLabels.Configuration
         public bool PreferCustomerPricing { get; set; } = true;
 
         /// <summary>
-        /// Sentinel held in <c>stdfpl__.kolom_10</c> marking a price list row as visible
-        /// to the quote web page - the equivalent of the <c>weblabel</c>/<c>rfqonw4l</c>
-        /// flags the other CERM parameter tables carry but this one does not.
-        /// Leave empty to use only the explicitly configured <see cref="Items"/>.
+        /// Whether to offer every active price list row that carries a non-blank Priority
+        /// (<c>stdfpl__.priorite</c>) in addition to the explicitly configured
+        /// <see cref="Items"/>.
         /// </summary>
-        public string WebFlagValue { get; set; } = string.Empty;
+        /// <remarks>
+        /// <c>stdfpl__</c> has no native <c>weblabel</c>/<c>rfqonw4l</c> flag like the
+        /// other CERM parameter tables feeding this page. Priority stands in for it:
+        /// estimators set it on the invoice price lines that belong on a quote, and it
+        /// already determines display order. Set false to fall back to <see cref="Items"/>
+        /// alone.
+        /// </remarks>
+        public bool IncludePrioritizedItems { get; set; } = true;
 
         /// <summary>Maximum quantity accepted for a single line item.</summary>
         public int MaxQuantity { get; set; } = 9999;

--- a/Configuration/LineItemOptions.cs
+++ b/Configuration/LineItemOptions.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+
+namespace WiseLabels.Configuration
+{
+    /// <summary>
+    /// Configuration for the quote line item catalogue, bound from
+    /// <c>QuoteOptions:LineItems</c>.
+    /// </summary>
+    public class LineItemOptions
+    {
+        /// <summary>Configuration section path.</summary>
+        public const string SectionName = "QuoteOptions:LineItems";
+
+        /// <summary>
+        /// The <c>stdfpl__.ktrk_ref</c> that holds the standard (non customer-specific)
+        /// price list. Empty string is the usual sentinel; confirm against the data.
+        /// </summary>
+        public string StandardCustomerRef { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Which CERM language column set to read descriptions from - 1 selects
+        /// <c>fkttxt11</c>/<c>fkttxt21</c>/<c>omsaant1</c>.
+        /// </summary>
+        public int LanguageIndex { get; set; } = 1;
+
+        /// <summary>
+        /// When true a customer's own price row wins over the standard list.
+        /// </summary>
+        public bool PreferCustomerPricing { get; set; } = true;
+
+        /// <summary>
+        /// Sentinel held in <c>stdfpl__.kolom_10</c> marking a price list row as visible
+        /// to the quote web page - the equivalent of the <c>weblabel</c>/<c>rfqonw4l</c>
+        /// flags the other CERM parameter tables carry but this one does not.
+        /// Leave empty to use only the explicitly configured <see cref="Items"/>.
+        /// </summary>
+        public string WebFlagValue { get; set; } = string.Empty;
+
+        /// <summary>Maximum quantity accepted for a single line item.</summary>
+        public int MaxQuantity { get; set; } = 9999;
+
+        /// <summary>Explicitly configured catalogue entries, keyed by CERM item ref.</summary>
+        public List<LineItemDefinition> Items { get; set; } = new();
+    }
+
+    /// <summary>
+    /// A configured catalogue entry: which CERM price list row it maps to, how it is
+    /// labelled, and when it should be offered or pre-ticked.
+    /// </summary>
+    public class LineItemDefinition
+    {
+        /// <summary>Stable key used in code and in persisted quotes, e.g. "CustomDie".</summary>
+        public string Key { get; set; } = string.Empty;
+
+        /// <summary>CERM price list item reference (<c>stdfpl__.fpl__ref</c>).</summary>
+        public string ItemRef { get; set; } = string.Empty;
+
+        /// <summary>Optional display label overriding the CERM description. Display only.</summary>
+        public string? Label { get; set; }
+
+        /// <summary>Display order in the grid.</summary>
+        public int Order { get; set; }
+
+        /// <summary>Quantity proposed when the row is first ticked.</summary>
+        public decimal DefaultQuantity { get; set; } = 1;
+
+        /// <summary>Whether the user may change the quantity.</summary>
+        public bool QuantityEditable { get; set; } = true;
+
+        /// <summary>
+        /// Conditions under which the row is offered at all. Empty means always offered -
+        /// which is the default, and the fix for charges that used to be unreachable.
+        /// </summary>
+        public List<LineItemCondition> OfferWhen { get; set; } = new();
+
+        /// <summary>
+        /// Conditions under which the row is pre-ticked. The user can always untick it.
+        /// </summary>
+        public List<LineItemCondition> AutoSelectWhen { get; set; } = new();
+
+        /// <summary>
+        /// Conditions under which the row is mandatory: ticked and not untickable.
+        /// </summary>
+        public List<LineItemCondition> ForceWhen { get; set; } = new();
+    }
+
+    /// <summary>
+    /// One applicability condition. All populated members must match for the condition
+    /// to hold; a rule list matches if ANY of its conditions hold.
+    /// </summary>
+    /// <remarks>
+    /// Conditions key on printing <em>IDs</em>, never on the printing label text - the
+    /// previous implementation sniffed the label for "spot"/"process color", which broke
+    /// as soon as a label was reworded.
+    /// </remarks>
+    public class LineItemCondition
+    {
+        /// <summary>Matches when the selected printing ID is in this list.</summary>
+        public List<string>? PrintingIdIn { get; set; }
+
+        /// <summary>Matches when the selected printing ID starts with one of these.</summary>
+        public List<string>? PrintingIdPrefixIn { get; set; }
+
+        /// <summary>Matches when the shape value/name is in this list.</summary>
+        public List<string>? ShapeIn { get; set; }
+
+        /// <summary>Matches when the corners value is NOT in this list.</summary>
+        public List<string>? CornersNotIn { get; set; }
+
+        /// <summary>Matches when "a custom die is required" equals this value.</summary>
+        public bool? CustomDie { get; set; }
+
+        /// <summary>Matches when "no existing die was selected" equals this value.</summary>
+        public bool? NoExistingDie { get; set; }
+    }
+}

--- a/Documentation/WiseLabels.xml
+++ b/Documentation/WiseLabels.xml
@@ -30,13 +30,19 @@
             When true a customer's own price row wins over the standard list.
             </summary>
         </member>
-        <member name="P:WiseLabels.Configuration.LineItemOptions.WebFlagValue">
+        <member name="P:WiseLabels.Configuration.LineItemOptions.IncludePrioritizedItems">
             <summary>
-            Sentinel held in <c>stdfpl__.kolom_10</c> marking a price list row as visible
-            to the quote web page - the equivalent of the <c>weblabel</c>/<c>rfqonw4l</c>
-            flags the other CERM parameter tables carry but this one does not.
-            Leave empty to use only the explicitly configured <see cref="P:WiseLabels.Configuration.LineItemOptions.Items"/>.
+            Whether to offer every active price list row that carries a non-blank Priority
+            (<c>stdfpl__.priorite</c>) in addition to the explicitly configured
+            <see cref="P:WiseLabels.Configuration.LineItemOptions.Items"/>.
             </summary>
+            <remarks>
+            <c>stdfpl__</c> has no native <c>weblabel</c>/<c>rfqonw4l</c> flag like the
+            other CERM parameter tables feeding this page. Priority stands in for it:
+            estimators set it on the invoice price lines that belong on a quote, and it
+            already determines display order. Set false to fall back to <see cref="P:WiseLabels.Configuration.LineItemOptions.Items"/>
+            alone.
+            </remarks>
         </member>
         <member name="P:WiseLabels.Configuration.LineItemOptions.MaxQuantity">
             <summary>Maximum quantity accepted for a single line item.</summary>

--- a/Documentation/WiseLabels.xml
+++ b/Documentation/WiseLabels.xml
@@ -4,6 +4,115 @@
         <name>WiseLabels</name>
     </assembly>
     <members>
+        <member name="T:WiseLabels.Configuration.LineItemOptions">
+            <summary>
+            Configuration for the quote line item catalogue, bound from
+            <c>QuoteOptions:LineItems</c>.
+            </summary>
+        </member>
+        <member name="F:WiseLabels.Configuration.LineItemOptions.SectionName">
+            <summary>Configuration section path.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemOptions.StandardCustomerRef">
+            <summary>
+            The <c>stdfpl__.ktrk_ref</c> that holds the standard (non customer-specific)
+            price list. Empty string is the usual sentinel; confirm against the data.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemOptions.LanguageIndex">
+            <summary>
+            Which CERM language column set to read descriptions from - 1 selects
+            <c>fkttxt11</c>/<c>fkttxt21</c>/<c>omsaant1</c>.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemOptions.PreferCustomerPricing">
+            <summary>
+            When true a customer's own price row wins over the standard list.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemOptions.WebFlagValue">
+            <summary>
+            Sentinel held in <c>stdfpl__.kolom_10</c> marking a price list row as visible
+            to the quote web page - the equivalent of the <c>weblabel</c>/<c>rfqonw4l</c>
+            flags the other CERM parameter tables carry but this one does not.
+            Leave empty to use only the explicitly configured <see cref="P:WiseLabels.Configuration.LineItemOptions.Items"/>.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemOptions.MaxQuantity">
+            <summary>Maximum quantity accepted for a single line item.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemOptions.Items">
+            <summary>Explicitly configured catalogue entries, keyed by CERM item ref.</summary>
+        </member>
+        <member name="T:WiseLabels.Configuration.LineItemDefinition">
+            <summary>
+            A configured catalogue entry: which CERM price list row it maps to, how it is
+            labelled, and when it should be offered or pre-ticked.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.Key">
+            <summary>Stable key used in code and in persisted quotes, e.g. "CustomDie".</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.ItemRef">
+            <summary>CERM price list item reference (<c>stdfpl__.fpl__ref</c>).</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.Label">
+            <summary>Optional display label overriding the CERM description. Display only.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.Order">
+            <summary>Display order in the grid.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.DefaultQuantity">
+            <summary>Quantity proposed when the row is first ticked.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.QuantityEditable">
+            <summary>Whether the user may change the quantity.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.OfferWhen">
+            <summary>
+            Conditions under which the row is offered at all. Empty means always offered -
+            which is the default, and the fix for charges that used to be unreachable.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.AutoSelectWhen">
+            <summary>
+            Conditions under which the row is pre-ticked. The user can always untick it.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemDefinition.ForceWhen">
+            <summary>
+            Conditions under which the row is mandatory: ticked and not untickable.
+            </summary>
+        </member>
+        <member name="T:WiseLabels.Configuration.LineItemCondition">
+            <summary>
+            One applicability condition. All populated members must match for the condition
+            to hold; a rule list matches if ANY of its conditions hold.
+            </summary>
+            <remarks>
+            Conditions key on printing <em>IDs</em>, never on the printing label text - the
+            previous implementation sniffed the label for "spot"/"process color", which broke
+            as soon as a label was reworded.
+            </remarks>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemCondition.PrintingIdIn">
+            <summary>Matches when the selected printing ID is in this list.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemCondition.PrintingIdPrefixIn">
+            <summary>Matches when the selected printing ID starts with one of these.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemCondition.ShapeIn">
+            <summary>Matches when the shape value/name is in this list.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemCondition.CornersNotIn">
+            <summary>Matches when the corners value is NOT in this list.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemCondition.CustomDie">
+            <summary>Matches when "a custom die is required" equals this value.</summary>
+        </member>
+        <member name="P:WiseLabels.Configuration.LineItemCondition.NoExistingDie">
+            <summary>Matches when "no existing die was selected" equals this value.</summary>
+        </member>
         <member name="T:WiseLabels.CustomAssemblyLoadContext">
             <summary>
             Custom assembly load context for loading assemblies and unmanaged libraries.
@@ -70,6 +179,188 @@
             <summary>
             Indicates whether all required fields have been collected.
             Set to true when shape, dimensions, material, printing, finish, and totalQuantity are all provided.
+            </summary>
+        </member>
+        <member name="T:WiseLabels.Models.LineItemPricing">
+             <summary>
+             The single source of truth for turning a CERM price basis, unit price and
+             quantity into a line total. Used by the quote form, the Confirm and Success
+             pages, the confirmation email, and (when enabled) the CERM invoice-line writer,
+             so those surfaces cannot disagree.
+             </summary>
+             <remarks>
+             Bases are the CERM "Price category" codes stored in <c>prys_srt</c>. Their order
+             is documented in the CERM help (Parameters / Accounting parameters / Invoice
+             price lines): Text, Discount/supplement, Fixed amount, /kg, /page, /piece, /100,
+             /1.000, /100.000, /1.000 kg, /counter unit, /m, /m2 - i.e. zero-indexed, so
+             /piece is '5' and /1.000 is '7'. This matches the arithmetic in
+             CERM-SQL/common/sql/estimates/Quote_Letter_Prices_ByCalculationId.sql, which
+             warns that confusing the two is "off by a factor of 1,000".
+            
+             Supported bases are an explicit WHITELIST. An unsupported basis is rejected when
+             the catalogue is loaded and can therefore never reach a multiplication here.
+             </remarks>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemPricing.TextOnly">
+            <summary>Free text; carries no price.</summary>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemPricing.FixedAmount">
+            <summary>A fixed amount, independent of quantity.</summary>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemPricing.PerPiece">
+            <summary>Price per piece.</summary>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemPricing.Per100">
+            <summary>Price per 100.</summary>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemPricing.Per1000">
+            <summary>Price per 1,000.</summary>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemPricing.Per100000">
+            <summary>Price per 100,000.</summary>
+        </member>
+        <member name="M:WiseLabels.Models.LineItemPricing.IsSupportedBasis(System.String)">
+            <summary>
+            Whether a price basis can be priced by <see cref="M:WiseLabels.Models.LineItemPricing.Total(System.String,System.Decimal,System.Decimal)"/>. Bases that depend
+            on data the quote form does not hold - '1' (percentage over other lines),
+            '3' (/kg), '4' (/page), '9' (/1.000 kg) and the letter codes - return false
+            and are dropped at catalogue load.
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Models.LineItemPricing.Total(System.String,System.Decimal,System.Decimal)">
+            <summary>
+            Computes the line total for a price basis, unit price and quantity.
+            Returns zero for an unsupported basis rather than guessing a multiplier.
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Models.LineItemPricing.TotalOf(System.Collections.Generic.IEnumerable{WiseLabels.Models.QuoteLineItem})">
+            <summary>Sums the totals of the selected line items.</summary>
+        </member>
+        <member name="M:WiseLabels.Models.LineItemPricing.IsQuantityBased(System.String)">
+            <summary>Whether the basis prices per unit (so a quantity is meaningful).</summary>
+        </member>
+        <member name="M:WiseLabels.Models.LineItemPricing.BasisLabel(System.String)">
+            <summary>Short human label for the basis, for the "Units" column.</summary>
+        </member>
+        <member name="T:WiseLabels.Models.LineItemSource">
+            <summary>
+            Where a line item on a quote came from. Mirrors the "Kind" column on the
+            CERM desktop's invoice-lines grid.
+            </summary>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemSource.Rule">
+            <summary>Proposed by an applicability rule (the common case).</summary>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemSource.Customer">
+            <summary>Came from the customer's own price list in CERM.</summary>
+        </member>
+        <member name="F:WiseLabels.Models.LineItemSource.Manual">
+            <summary>Ticked by the user even though no rule proposed it.</summary>
+        </member>
+        <member name="T:WiseLabels.Models.QuoteLineItem">
+            <summary>
+            One selectable charge on a quote, sourced from the CERM standard price list
+            (<c>stdfpl__</c>) and destined - once selected - for a CERM calculation
+            invoice line (<c>v1facl__</c>).
+            </summary>
+            <remarks>
+            There is deliberately no <c>Total</c> property. System.Text.Json serializes
+            get-only properties, which would persist a value that is ignored on read and
+            then drift from the recomputed one. Use <see cref="M:WiseLabels.Models.LineItemPricing.Total(System.String,System.Decimal,System.Decimal)"/>.
+            </remarks>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.ItemRef">
+            <summary>CERM price list item reference (<c>stdfpl__.fpl__ref</c>).</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.CustomerRef">
+            <summary>The <c>ktrk_ref</c> the price row was read from, for traceability.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Key">
+            <summary>Stable configuration key, e.g. "CustomDie". Independent of the item ref.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Description">
+            <summary>First description line (<c>fkttxt1{lang}</c>).</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Description2">
+            <summary>
+            Second description line (<c>fkttxt2{lang}</c>). CERM treats the two as two
+            LINES of one description and joins them with a newline on the quote letter.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Unit">
+            <summary>Unit text (<c>omsaant{lang}</c>), e.g. "each".</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.UnitPrice">
+            <summary>Unit price excluding tax (<c>prijs_bm</c>), captured when the quote was priced.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Quantity">
+            <summary>Quantity the charge is billed for. Maps to <c>v1facl__.f_aantal</c>.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Selected">
+            <summary>Whether this charge is included on the quote.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Forced">
+            <summary>
+            True when the charge is mandatory for this quote and cannot be unticked
+            (currently: the die charge when no existing die was chosen).
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.QuantityEditable">
+            <summary>Whether the quantity is user-editable, or pinned at <see cref="P:WiseLabels.Models.QuoteLineItem.Quantity"/>.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.PriceBasis">
+            <summary>CERM price category (<c>prys_srt</c>). See <see cref="T:WiseLabels.Models.LineItemPricing"/>.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Currency">
+            <summary>Currency of <see cref="P:WiseLabels.Models.QuoteLineItem.UnitPrice"/> (<c>munt_ref</c>).</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Source">
+            <summary>How this item came to be on the quote.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Order">
+            <summary>Display order within the grid.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteLineItem.Total">
+            <summary>Convenience for views; not serialized.</summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteRequest.LineItems">
+            <summary>
+            Charges selected for this quote. Replaces the former per-charge scalars
+            (ColorChanges, DigitalVersionChanges, NeedsPressProof, PressProofQuantity,
+            NeedsSpotColorPlateChange, SpotColorPlateChangeQuantity); those are still
+            read from persisted JSON by <see cref="T:WiseLabels.Models.QuoteRequestCompat"/>.
+            </summary>
+        </member>
+        <member name="P:WiseLabels.Models.QuoteRequest.Extra">
+            <summary>
+            Captures JSON properties this model no longer declares, so a QuoteRequest
+            serialized by an earlier build (in TempData or in the session) can still be
+            upgraded rather than silently losing its charges. See <see cref="T:WiseLabels.Models.QuoteRequestCompat"/>.
+            </summary>
+        </member>
+        <member name="T:WiseLabels.Models.QuoteRequestCompat">
+             <summary>
+             One-release compatibility shim. A <see cref="T:WiseLabels.Models.QuoteRequest"/> serialized by an
+             earlier build carries the six per-charge scalars instead of a
+             <see cref="P:WiseLabels.Models.QuoteRequest.LineItems"/> collection. Those blobs live in TempData
+             (a quote in flight across a deploy) and in the session under
+             <c>SelectedQuoteSelection</c> (written by a different page, 30-minute lifetime),
+             so they outlive the deploy that removes the properties.
+            
+             Delete this file, the call sites, and <see cref="P:WiseLabels.Models.QuoteRequest.Extra"/> one
+             release after the model change has shipped.
+             </summary>
+        </member>
+        <member name="F:WiseLabels.Models.QuoteRequestCompat.LegacyCharges">
+            <summary>Legacy scalar name to line item configuration key.</summary>
+        </member>
+        <member name="M:WiseLabels.Models.QuoteRequestCompat.UpgradeLegacyLineItems(WiseLabels.Models.QuoteRequest)">
+            <summary>
+            Rebuilds <see cref="P:WiseLabels.Models.QuoteRequest.LineItems"/> from legacy scalars found in
+            <see cref="P:WiseLabels.Models.QuoteRequest.Extra"/>. Prices are not recovered - they are
+            re-resolved from the catalogue by item ref - so only selection and quantity
+            carry over, which is all that was ever user-supplied.
+            No-op when the quote already has line items or carries no legacy data.
             </summary>
         </member>
         <member name="T:WiseLabels.Pages.Api.CermCalculationModel">
@@ -179,6 +470,20 @@
             This routine attempts case-insensitive lookup for common property names.
             </summary>
         </member>
+        <member name="T:WiseLabels.Pages.Api.LineItemsModel">
+            <summary>
+            Returns the selectable charge catalogue for a quote, with the applicability rules
+            already evaluated server-side so the browser never has to reimplement them.
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Pages.Api.LineItemsModel.#ctor(Microsoft.Extensions.Logging.ILogger{WiseLabels.Pages.Api.LineItemsModel},WiseLabels.Services.ILineItemCatalogService)">
+            <summary>Creates the endpoint.</summary>
+        </member>
+        <member name="M:WiseLabels.Pages.Api.LineItemsModel.OnGetAsync(System.String,System.String,System.String,System.String,System.Boolean,System.Boolean)">
+            <summary>
+            GET /Api/LineItems?customerId=&amp;printingId=&amp;shapeValue=&amp;cornersValue=&amp;isCustomDie=&amp;hasExistingDie=
+            </summary>
+        </member>
         <member name="M:WiseLabels.Pages.Api.MaterialsModel.GetAllowedMaterialIdsAsync(System.String)">
             <summary>
             Queries the database to get material IDs that are allowed for the given printing selection.
@@ -214,11 +519,40 @@
             Tries two approaches: body-only and basic auth + body.
             </summary>
         </member>
+        <member name="M:WiseLabels.Pages.ConfirmModel.LoadLineItemPricesAsync">
+            <summary>
+            Re-prices the quote's line items against the CERM price list.
+            Prices are never taken from the posted form - see
+            <see cref="M:WiseLabels.Services.ILineItemCatalogService.ResolvePostedAsync(WiseLabels.Services.LineItemContext,System.Collections.Generic.IEnumerable{WiseLabels.Models.QuoteLineItem})"/>.
+            </summary>
+        </member>
         <member name="P:WiseLabels.Pages.GetQuoteModel.ApiRequestJson">
             <summary>JSON payload that was sent to CERM API (for debugging on error).</summary>
         </member>
         <member name="P:WiseLabels.Pages.GetQuoteModel.ApiResponseJson">
             <summary>JSON response from CERM API (for debugging on error).</summary>
+        </member>
+        <member name="P:WiseLabels.Pages.GetQuoteModel.LineItemCatalog">
+            <summary>Charges offered for this quote, with rule-driven pre-selection applied.</summary>
+        </member>
+        <member name="M:WiseLabels.Pages.GetQuoteModel.LoadLineItemCatalogAsync">
+            <summary>
+            Loads the charge catalogue for the current form state, merging in any
+            selections carried by a saved quote so an edited quote round-trips.
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Pages.GetQuoteModel.ParseLineItemsFromForm(Microsoft.AspNetCore.Http.IFormCollection)">
+            <summary>
+            Reads the line item grid's single JSON field. Only selection and quantity are
+            taken from it; everything price-bearing is re-resolved from CERM.
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Pages.GetQuoteModel.BuildQuoteRequest(Microsoft.AspNetCore.Http.IFormCollection,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int64})">
+            <summary>
+            Builds a <see cref="T:WiseLabels.Models.QuoteRequest"/> from the posted form.
+            This is the single binder used by the submit path and by both file-upload
+            failure paths, so a validation error never silently drops fields.
+            </summary>
         </member>
         <member name="P:WiseLabels.Pages.SuccessModel.CermCalculationId">
             <summary>CERM calculation ID (Data.Id) from submission.</summary>
@@ -270,6 +604,13 @@
             komment1: Full name and company (max 60 chars)
             komment2: Email and phone number (max 60 chars)
             komment3: Additional comments (max 60 chars)
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Services.EmailService.BuildAdditionalChargesTable(System.Collections.Generic.IReadOnlyList{WiseLabels.Models.QuoteLineItem})">
+            <summary>
+            Renders the selected line item charges. Shares
+            <see cref="M:WiseLabels.Models.LineItemPricing.Total(System.String,System.Decimal,System.Decimal)"/> with the Confirm and Success pages, so the
+            emailed total cannot disagree with what the customer saw on screen.
             </summary>
         </member>
         <member name="T:WiseLabels.Services.ICermAuthService">
@@ -333,6 +674,104 @@
             <param name="quoteNumber">The quote number (bon__ref)</param>
             <param name="quoteRequest">Quote request containing customer contact details</param>
             <returns>True if successfully updated, false otherwise</returns>
+        </member>
+        <member name="T:WiseLabels.Services.LineItemContext">
+            <summary>
+            Facts about a quote that decide which line items are offered and pre-ticked.
+            </summary>
+            <param name="CustomerId">CERM customer, used to pick customer-specific pricing.</param>
+            <param name="PrintingId">Selected printing/colour code ID (never the label text).</param>
+            <param name="ShapeValue">Selected shape value.</param>
+            <param name="CornersValue">Selected corners value.</param>
+            <param name="IsCustomDie">Whether dimension matching flagged a custom die.</param>
+            <param name="HasExistingDie">Whether the user picked an existing die from the list.</param>
+        </member>
+        <member name="M:WiseLabels.Services.LineItemContext.#ctor(System.String,System.String,System.String,System.String,System.Boolean,System.Boolean)">
+            <summary>
+            Facts about a quote that decide which line items are offered and pre-ticked.
+            </summary>
+            <param name="CustomerId">CERM customer, used to pick customer-specific pricing.</param>
+            <param name="PrintingId">Selected printing/colour code ID (never the label text).</param>
+            <param name="ShapeValue">Selected shape value.</param>
+            <param name="CornersValue">Selected corners value.</param>
+            <param name="IsCustomDie">Whether dimension matching flagged a custom die.</param>
+            <param name="HasExistingDie">Whether the user picked an existing die from the list.</param>
+        </member>
+        <member name="P:WiseLabels.Services.LineItemContext.CustomerId">
+            <summary>CERM customer, used to pick customer-specific pricing.</summary>
+        </member>
+        <member name="P:WiseLabels.Services.LineItemContext.PrintingId">
+            <summary>Selected printing/colour code ID (never the label text).</summary>
+        </member>
+        <member name="P:WiseLabels.Services.LineItemContext.ShapeValue">
+            <summary>Selected shape value.</summary>
+        </member>
+        <member name="P:WiseLabels.Services.LineItemContext.CornersValue">
+            <summary>Selected corners value.</summary>
+        </member>
+        <member name="P:WiseLabels.Services.LineItemContext.IsCustomDie">
+            <summary>Whether dimension matching flagged a custom die.</summary>
+        </member>
+        <member name="P:WiseLabels.Services.LineItemContext.HasExistingDie">
+            <summary>Whether the user picked an existing die from the list.</summary>
+        </member>
+        <member name="T:WiseLabels.Services.ILineItemCatalogService">
+            <summary>
+            Loads the selectable charge catalogue for a quote from the CERM standard price
+            list, applies the configured labelling and applicability rules, and merges in any
+            selections already made on the quote.
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Services.ILineItemCatalogService.GetCatalogAsync(WiseLabels.Services.LineItemContext,System.Collections.Generic.IEnumerable{WiseLabels.Models.QuoteLineItem})">
+            <summary>
+            Builds the catalogue for a quote. Never throws: a database failure yields an
+            empty catalogue so the quote stays submittable, matching prior behaviour.
+            </summary>
+            <param name="context">Quote facts used to evaluate the rules.</param>
+            <param name="existing">Selections already made, merged in by item ref/key.</param>
+        </member>
+        <member name="M:WiseLabels.Services.ILineItemCatalogService.ResolvePostedAsync(WiseLabels.Services.LineItemContext,System.Collections.Generic.IEnumerable{WiseLabels.Models.QuoteLineItem})">
+            <summary>
+            Re-resolves posted line items against the catalogue: descriptions, units,
+            prices and price bases come from CERM, and only selection and quantity are
+            taken from the caller. Posted items with no catalogue match are dropped.
+            </summary>
+            <remarks>
+            This is the trust boundary. The quote form is user-editable, so a posted
+            price must never be believed.
+            </remarks>
+        </member>
+        <member name="T:WiseLabels.Services.LineItemCatalogService">
+            <inheritdoc cref="T:WiseLabels.Services.ILineItemCatalogService"/>
+        </member>
+        <member name="M:WiseLabels.Services.LineItemCatalogService.#ctor(CERM.DataAccess.Repositories.PriceList.IPriceListItemRepository,Microsoft.Extensions.Options.IOptions{WiseLabels.Configuration.LineItemOptions},Microsoft.Extensions.Logging.ILogger{WiseLabels.Services.LineItemCatalogService})">
+            <summary>Creates the service.</summary>
+        </member>
+        <member name="M:WiseLabels.Services.LineItemCatalogService.GetCatalogAsync(WiseLabels.Services.LineItemContext,System.Collections.Generic.IEnumerable{WiseLabels.Models.QuoteLineItem})">
+            <inheritdoc />
+        </member>
+        <member name="M:WiseLabels.Services.LineItemCatalogService.ResolvePostedAsync(WiseLabels.Services.LineItemContext,System.Collections.Generic.IEnumerable{WiseLabels.Models.QuoteLineItem})">
+            <inheritdoc />
+        </member>
+        <member name="M:WiseLabels.Services.LineItemCatalogService.Project(CERM.DataAccess.Models.PriceListItem,WiseLabels.Configuration.LineItemDefinition)">
+            <summary>
+            Projects a CERM price list row into a quote line item, selecting the language
+            columns and rejecting price bases this application cannot price.
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Services.LineItemCatalogService.SelectLanguage(CERM.DataAccess.Models.PriceListItem,System.Int32)">
+            <summary>
+            CERM stores descriptions as <c>fkttxt{line}{language}</c> - two LINES of one
+            description per language, joined with a newline on the quote letter. Reading
+            only <c>fkttxt11</c> silently drops the second line.
+            </summary>
+        </member>
+        <member name="M:WiseLabels.Services.LineItemCatalogService.Matches(System.Collections.Generic.List{WiseLabels.Configuration.LineItemCondition},WiseLabels.Services.LineItemContext,System.Boolean)">
+            <summary>
+            Evaluates a rule list. A list matches if ANY condition holds; an empty or
+            missing list falls back to <paramref name="offeredByDefault"/>, which is how
+            "always offered" is expressed.
+            </summary>
         </member>
         <member name="M:WiseLabels.Services.QuoteService.BuildCermPayloadJson(WiseLabels.Models.QuoteRequest)">
             <summary>

--- a/Models/LineItemPricing.cs
+++ b/Models/LineItemPricing.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+
+namespace WiseLabels.Models
+{
+    /// <summary>
+    /// The single source of truth for turning a CERM price basis, unit price and
+    /// quantity into a line total. Used by the quote form, the Confirm and Success
+    /// pages, the confirmation email, and (when enabled) the CERM invoice-line writer,
+    /// so those surfaces cannot disagree.
+    /// </summary>
+    /// <remarks>
+    /// Bases are the CERM "Price category" codes stored in <c>prys_srt</c>. Their order
+    /// is documented in the CERM help (Parameters / Accounting parameters / Invoice
+    /// price lines): Text, Discount/supplement, Fixed amount, /kg, /page, /piece, /100,
+    /// /1.000, /100.000, /1.000 kg, /counter unit, /m, /m2 - i.e. zero-indexed, so
+    /// /piece is '5' and /1.000 is '7'. This matches the arithmetic in
+    /// CERM-SQL/common/sql/estimates/Quote_Letter_Prices_ByCalculationId.sql, which
+    /// warns that confusing the two is "off by a factor of 1,000".
+    ///
+    /// Supported bases are an explicit WHITELIST. An unsupported basis is rejected when
+    /// the catalogue is loaded and can therefore never reach a multiplication here.
+    /// </remarks>
+    public static class LineItemPricing
+    {
+        /// <summary>Free text; carries no price.</summary>
+        public const string TextOnly = "0";
+        /// <summary>A fixed amount, independent of quantity.</summary>
+        public const string FixedAmount = "2";
+        /// <summary>Price per piece.</summary>
+        public const string PerPiece = "5";
+        /// <summary>Price per 100.</summary>
+        public const string Per100 = "6";
+        /// <summary>Price per 1,000.</summary>
+        public const string Per1000 = "7";
+        /// <summary>Price per 100,000.</summary>
+        public const string Per100000 = "8";
+
+        private static readonly HashSet<string> Supported = new(StringComparer.Ordinal)
+        {
+            TextOnly, FixedAmount, PerPiece, Per100, Per1000, Per100000
+        };
+
+        /// <summary>
+        /// Whether a price basis can be priced by <see cref="Total"/>. Bases that depend
+        /// on data the quote form does not hold - '1' (percentage over other lines),
+        /// '3' (/kg), '4' (/page), '9' (/1.000 kg) and the letter codes - return false
+        /// and are dropped at catalogue load.
+        /// </summary>
+        public static bool IsSupportedBasis(string? priceBasis) =>
+            !string.IsNullOrWhiteSpace(priceBasis) && Supported.Contains(priceBasis.Trim());
+
+        /// <summary>
+        /// Computes the line total for a price basis, unit price and quantity.
+        /// Returns zero for an unsupported basis rather than guessing a multiplier.
+        /// </summary>
+        public static decimal Total(string? priceBasis, decimal unitPrice, decimal quantity)
+        {
+            var basis = (priceBasis ?? string.Empty).Trim();
+            return basis switch
+            {
+                TextOnly => 0m,
+                FixedAmount => unitPrice,
+                PerPiece => unitPrice * quantity,
+                Per100 => unitPrice * quantity / 100m,
+                Per1000 => unitPrice * quantity / 1000m,
+                Per100000 => unitPrice * quantity / 100000m,
+                _ => 0m
+            };
+        }
+
+        /// <summary>Sums the totals of the selected line items.</summary>
+        public static decimal TotalOf(IEnumerable<QuoteLineItem>? items)
+        {
+            if (items == null) return 0m;
+            var sum = 0m;
+            foreach (var item in items)
+            {
+                if (item.Selected)
+                {
+                    sum += Total(item.PriceBasis, item.UnitPrice, item.Quantity);
+                }
+            }
+            return sum;
+        }
+
+        /// <summary>Whether the basis prices per unit (so a quantity is meaningful).</summary>
+        public static bool IsQuantityBased(string? priceBasis)
+        {
+            var basis = (priceBasis ?? string.Empty).Trim();
+            return basis is PerPiece or Per100 or Per1000 or Per100000;
+        }
+
+        /// <summary>Short human label for the basis, for the "Units" column.</summary>
+        public static string BasisLabel(string? priceBasis) =>
+            (priceBasis ?? string.Empty).Trim() switch
+            {
+                TextOnly => "",
+                FixedAmount => "fixed",
+                PerPiece => "each",
+                Per100 => "per 100",
+                Per1000 => "per 1,000",
+                Per100000 => "per 100,000",
+                _ => ""
+            };
+    }
+}

--- a/Models/QuoteLineItem.cs
+++ b/Models/QuoteLineItem.cs
@@ -1,0 +1,86 @@
+using System.Text.Json.Serialization;
+
+namespace WiseLabels.Models
+{
+    /// <summary>
+    /// Where a line item on a quote came from. Mirrors the "Kind" column on the
+    /// CERM desktop's invoice-lines grid.
+    /// </summary>
+    public enum LineItemSource
+    {
+        /// <summary>Proposed by an applicability rule (the common case).</summary>
+        Rule = 0,
+        /// <summary>Came from the customer's own price list in CERM.</summary>
+        Customer = 1,
+        /// <summary>Ticked by the user even though no rule proposed it.</summary>
+        Manual = 2
+    }
+
+    /// <summary>
+    /// One selectable charge on a quote, sourced from the CERM standard price list
+    /// (<c>stdfpl__</c>) and destined - once selected - for a CERM calculation
+    /// invoice line (<c>v1facl__</c>).
+    /// </summary>
+    /// <remarks>
+    /// There is deliberately no <c>Total</c> property. System.Text.Json serializes
+    /// get-only properties, which would persist a value that is ignored on read and
+    /// then drift from the recomputed one. Use <see cref="LineItemPricing.Total"/>.
+    /// </remarks>
+    public class QuoteLineItem
+    {
+        /// <summary>CERM price list item reference (<c>stdfpl__.fpl__ref</c>).</summary>
+        public string ItemRef { get; set; } = string.Empty;
+
+        /// <summary>The <c>ktrk_ref</c> the price row was read from, for traceability.</summary>
+        public string? CustomerRef { get; set; }
+
+        /// <summary>Stable configuration key, e.g. "CustomDie". Independent of the item ref.</summary>
+        public string Key { get; set; } = string.Empty;
+
+        /// <summary>First description line (<c>fkttxt1{lang}</c>).</summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Second description line (<c>fkttxt2{lang}</c>). CERM treats the two as two
+        /// LINES of one description and joins them with a newline on the quote letter.
+        /// </summary>
+        public string? Description2 { get; set; }
+
+        /// <summary>Unit text (<c>omsaant{lang}</c>), e.g. "each".</summary>
+        public string Unit { get; set; } = "each";
+
+        /// <summary>Unit price excluding tax (<c>prijs_bm</c>), captured when the quote was priced.</summary>
+        public decimal UnitPrice { get; set; }
+
+        /// <summary>Quantity the charge is billed for. Maps to <c>v1facl__.f_aantal</c>.</summary>
+        public decimal Quantity { get; set; } = 1;
+
+        /// <summary>Whether this charge is included on the quote.</summary>
+        public bool Selected { get; set; }
+
+        /// <summary>
+        /// True when the charge is mandatory for this quote and cannot be unticked
+        /// (currently: the die charge when no existing die was chosen).
+        /// </summary>
+        public bool Forced { get; set; }
+
+        /// <summary>Whether the quantity is user-editable, or pinned at <see cref="Quantity"/>.</summary>
+        public bool QuantityEditable { get; set; } = true;
+
+        /// <summary>CERM price category (<c>prys_srt</c>). See <see cref="LineItemPricing"/>.</summary>
+        public string PriceBasis { get; set; } = LineItemPricing.PerPiece;
+
+        /// <summary>Currency of <see cref="UnitPrice"/> (<c>munt_ref</c>).</summary>
+        public string? Currency { get; set; }
+
+        /// <summary>How this item came to be on the quote.</summary>
+        public LineItemSource Source { get; set; } = LineItemSource.Rule;
+
+        /// <summary>Display order within the grid.</summary>
+        public int Order { get; set; }
+
+        /// <summary>Convenience for views; not serialized.</summary>
+        [JsonIgnore]
+        public decimal Total => LineItemPricing.Total(PriceBasis, UnitPrice, Quantity);
+    }
+}

--- a/Models/QuoteRequest.cs
+++ b/Models/QuoteRequest.cs
@@ -1,3 +1,6 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace WiseLabels.Models
 {
     public class QuoteRequest
@@ -27,12 +30,6 @@ namespace WiseLabels.Models
         public string? CuttingDie { get; set; }
         public string? DieSizeInfo { get; set; }
         public bool IsCustomDie { get; set; }
-        public int? ColorChanges { get; set; }
-        public int? DigitalVersionChanges { get; set; }
-        public bool NeedsPressProof { get; set; }
-        public int? PressProofQuantity { get; set; }
-        public bool NeedsSpotColorPlateChange { get; set; }
-        public int? SpotColorPlateChangeQuantity { get; set; }
         public string? Printing { get; set; }
         public string? Material { get; set; }
         public string? ColorCode { get; set; }
@@ -66,6 +63,22 @@ namespace WiseLabels.Models
         
         public List<QuotePriceBreakdown>? PriceBreakdown { get; set; }
         public string? QuickQuoteResponseJson { get; set; }
+
+        /// <summary>
+        /// Charges selected for this quote. Replaces the former per-charge scalars
+        /// (ColorChanges, DigitalVersionChanges, NeedsPressProof, PressProofQuantity,
+        /// NeedsSpotColorPlateChange, SpotColorPlateChangeQuantity); those are still
+        /// read from persisted JSON by <see cref="QuoteRequestCompat"/>.
+        /// </summary>
+        public List<QuoteLineItem>? LineItems { get; set; }
+
+        /// <summary>
+        /// Captures JSON properties this model no longer declares, so a QuoteRequest
+        /// serialized by an earlier build (in TempData or in the session) can still be
+        /// upgraded rather than silently losing its charges. See <see cref="QuoteRequestCompat"/>.
+        /// </summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? Extra { get; set; }
 
         public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
     }

--- a/Models/QuoteRequestCompat.cs
+++ b/Models/QuoteRequestCompat.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace WiseLabels.Models
+{
+    /// <summary>
+    /// One-release compatibility shim. A <see cref="QuoteRequest"/> serialized by an
+    /// earlier build carries the six per-charge scalars instead of a
+    /// <see cref="QuoteRequest.LineItems"/> collection. Those blobs live in TempData
+    /// (a quote in flight across a deploy) and in the session under
+    /// <c>SelectedQuoteSelection</c> (written by a different page, 30-minute lifetime),
+    /// so they outlive the deploy that removes the properties.
+    ///
+    /// Delete this file, the call sites, and <see cref="QuoteRequest.Extra"/> one
+    /// release after the model change has shipped.
+    /// </summary>
+    public static class QuoteRequestCompat
+    {
+        /// <summary>Legacy scalar name to line item configuration key.</summary>
+        private static readonly (string Legacy, string Key, string? QuantityProperty)[] LegacyCharges =
+        {
+            ("needsPressProof",           "PressProof",           "pressProofQuantity"),
+            ("needsSpotColorPlateChange", "SpotColorPlateChange", "spotColorPlateChangeQuantity")
+        };
+
+        private static readonly (string Legacy, string Key)[] LegacyCounts =
+        {
+            ("colorChanges",          "ColorChanges"),
+            ("digitalVersionChanges", "DigitalVersionChanges")
+        };
+
+        /// <summary>
+        /// Rebuilds <see cref="QuoteRequest.LineItems"/> from legacy scalars found in
+        /// <see cref="QuoteRequest.Extra"/>. Prices are not recovered - they are
+        /// re-resolved from the catalogue by item ref - so only selection and quantity
+        /// carry over, which is all that was ever user-supplied.
+        /// No-op when the quote already has line items or carries no legacy data.
+        /// </summary>
+        public static void UpgradeLegacyLineItems(QuoteRequest? quote)
+        {
+            if (quote?.Extra == null || quote.Extra.Count == 0) return;
+            if (quote.LineItems is { Count: > 0 }) { quote.Extra = null; return; }
+
+            var recovered = new List<QuoteLineItem>();
+
+            foreach (var (legacy, key) in LegacyCounts)
+            {
+                var count = ReadInt(quote.Extra, legacy);
+                if (count is > 0)
+                {
+                    recovered.Add(new QuoteLineItem
+                    {
+                        Key = key,
+                        Selected = true,
+                        Quantity = count.Value,
+                        Source = LineItemSource.Rule
+                    });
+                }
+            }
+
+            foreach (var (legacy, key, quantityProperty) in LegacyCharges)
+            {
+                if (ReadBool(quote.Extra, legacy) == true)
+                {
+                    var quantity = quantityProperty == null ? null : ReadInt(quote.Extra, quantityProperty);
+                    recovered.Add(new QuoteLineItem
+                    {
+                        Key = key,
+                        Selected = true,
+                        Quantity = quantity is > 0 ? quantity.Value : 1,
+                        Source = LineItemSource.Rule
+                    });
+                }
+            }
+
+            if (recovered.Count > 0)
+            {
+                quote.LineItems = recovered;
+            }
+
+            quote.Extra = null;
+        }
+
+        private static bool TryGet(Dictionary<string, JsonElement> extra, string name, out JsonElement value)
+        {
+            // TempData is written with default (PascalCase) options on some paths and
+            // camelCase on others, so match case-insensitively.
+            foreach (var pair in extra)
+            {
+                if (string.Equals(pair.Key, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = pair.Value;
+                    return true;
+                }
+            }
+            value = default;
+            return false;
+        }
+
+        private static int? ReadInt(Dictionary<string, JsonElement> extra, string name)
+        {
+            if (!TryGet(extra, name, out var element)) return null;
+            return element.ValueKind switch
+            {
+                JsonValueKind.Number when element.TryGetInt32(out var n) => n,
+                JsonValueKind.String when int.TryParse(element.GetString(), out var s) => s,
+                _ => null
+            };
+        }
+
+        private static bool? ReadBool(Dictionary<string, JsonElement> extra, string name)
+        {
+            if (!TryGet(extra, name, out var element)) return null;
+            return element.ValueKind switch
+            {
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.String when bool.TryParse(element.GetString(), out var b) => b,
+                _ => null
+            };
+        }
+    }
+}

--- a/Pages/Api/LineItems.cshtml
+++ b/Pages/Api/LineItems.cshtml
@@ -1,0 +1,2 @@
+@page
+@model WiseLabels.Pages.Api.LineItemsModel

--- a/Pages/Api/LineItems.cshtml.cs
+++ b/Pages/Api/LineItems.cshtml.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using WiseLabels.Services;
+
+namespace WiseLabels.Pages.Api
+{
+    /// <summary>
+    /// Returns the selectable charge catalogue for a quote, with the applicability rules
+    /// already evaluated server-side so the browser never has to reimplement them.
+    /// </summary>
+    [IgnoreAntiforgeryToken]
+    public class LineItemsModel : PageModel
+    {
+        private readonly ILogger<LineItemsModel> _logger;
+        private readonly ILineItemCatalogService _lineItemCatalog;
+
+        /// <summary>Creates the endpoint.</summary>
+        public LineItemsModel(ILogger<LineItemsModel> logger, ILineItemCatalogService lineItemCatalog)
+        {
+            _logger = logger;
+            _lineItemCatalog = lineItemCatalog;
+        }
+
+        /// <summary>
+        /// GET /Api/LineItems?customerId=&amp;printingId=&amp;shapeValue=&amp;cornersValue=&amp;isCustomDie=&amp;hasExistingDie=
+        /// </summary>
+        public async Task<IActionResult> OnGetAsync(
+            string? customerId = null,
+            string? printingId = null,
+            string? shapeValue = null,
+            string? cornersValue = null,
+            bool isCustomDie = false,
+            bool hasExistingDie = false)
+        {
+            try
+            {
+                var context = new LineItemContext(
+                    CustomerId: customerId,
+                    PrintingId: printingId,
+                    ShapeValue: shapeValue,
+                    CornersValue: cornersValue,
+                    IsCustomDie: isCustomDie,
+                    HasExistingDie: hasExistingDie);
+
+                var catalog = await _lineItemCatalog.GetCatalogAsync(context);
+
+                return new JsonResult(new { lineItems = catalog });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error loading the line item catalogue for customer {CustomerId}", customerId);
+                return StatusCode(500, new { error = "Unable to load line items." });
+            }
+        }
+    }
+}

--- a/Pages/Confirm.cshtml
+++ b/Pages/Confirm.cshtml
@@ -1,4 +1,4 @@
-@page
+﻿@page
 @model WiseLabels.Pages.ConfirmModel
 @using WiseLabels.Models
 @using System.Globalization
@@ -459,118 +459,7 @@
             </tbody>
         </table>
 
-        <section class="additional-charges">
-            <h3>Additional Charges (if applicable)</h3>
-            <table>
-                <thead>
-                    <tr>
-                        <th style="width: 55%;">Description</th>
-                        <th style="width: 20%;" class="text-right">Price</th>
-                        <th style="width: 15%;">Units</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @* Additional line items for custom die and other charges *@
-                    @{
-                        var hasAnyCharges = (Model.QuoteRequest?.IsCustomDie == true && Model.AdditionalCharges.ContainsKey("CustomDie")) 
-                            || (Model.QuoteRequest?.ColorChanges > 0 && Model.AdditionalCharges.ContainsKey("ColorChanges"))
-                            || (Model.QuoteRequest?.DigitalVersionChanges > 0 && Model.AdditionalCharges.ContainsKey("DigitalVersionChanges"))
-                            || (Model.QuoteRequest?.NeedsPressProof == true && Model.AdditionalCharges.ContainsKey("PressProof"))
-                            || (Model.QuoteRequest?.NeedsSpotColorPlateChange == true && Model.AdditionalCharges.ContainsKey("SpotColorPlateChange"));
-                    }
-
-                    @if (Model.QuoteRequest?.IsCustomDie == true && Model.AdditionalCharges.TryGetValue("CustomDie", out var customDieCharge))
-                    {
-                        <tr style="background: #fef3c7;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #92400e;">⚠️</span> Custom Die Fabrication
-                                <br />
-                                <small style="color: #78350f; font-weight: normal;">
-                                    Die Size: @FormatMaybeValue(Model.QuoteRequest?.DieSizeInfo)
-                                </small>
-                            </td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(customDieCharge.Price)</td>
-                            <td style="font-weight: 600;">@(customDieCharge.Unit)</td>
-                        </tr>
-                    }
-
-                    @if (Model.QuoteRequest?.ColorChanges > 0 && Model.AdditionalCharges.TryGetValue("ColorChanges", out var colorChangesCharge))
-                    {
-                        var totalColorChangePrice = colorChangesCharge.Price * Model.QuoteRequest.ColorChanges.Value;
-                        <tr style="background: #dbeafe;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #1e40af;">🎨</span> Color Changes
-                                <br />
-                                <small style="color: #1e3a8a; font-weight: normal;">
-                                    @Model.QuoteRequest.ColorChanges changes × @FormatCurrency(colorChangesCharge.Price) per change
-                                </small>
-                            </td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(totalColorChangePrice)</td>
-                            <td style="font-weight: 600;">total</td>
-                        </tr>
-                    }
-
-                    @if (Model.QuoteRequest?.DigitalVersionChanges > 0 && Model.AdditionalCharges.TryGetValue("DigitalVersionChanges", out var digitalVersionChangesCharge))
-                    {
-                        var totalDigitalVersionChangePrice = digitalVersionChangesCharge.Price * Model.QuoteRequest.DigitalVersionChanges.Value;
-                        <tr style="background: #e0e7ff;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #3730a3;">🖨️</span> Digital Full Color Version Changes
-                                <br />
-                                <small style="color: #312e81; font-weight: normal;">
-                                    @Model.QuoteRequest.DigitalVersionChanges changes × @FormatCurrency(digitalVersionChangesCharge.Price) per change
-                                </small>
-                            </td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(totalDigitalVersionChangePrice)</td>
-                            <td style="font-weight: 600;">total</td>
-                        </tr>
-                    }
-
-                    @if (Model.QuoteRequest?.NeedsPressProof == true && Model.AdditionalCharges.TryGetValue("PressProof", out var pressProofCharge))
-                    {
-                        var pressProofQty = Model.QuoteRequest.PressProofQuantity ?? 1;
-                        var totalPressProofPrice = pressProofCharge.Price * pressProofQty;
-                        <tr style="background: #fce7f3;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #9f1239;">📄</span> Press Proof - Print Only, Not Die Cut
-                                <br />
-                                <small style="color: #881337; font-weight: normal;">
-                                    @pressProofQty × @FormatCurrency(pressProofCharge.Price) @(pressProofCharge.Unit)
-                                </small>
-                            </td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(totalPressProofPrice)</td>
-                            <td style="font-weight: 600;">total</td>
-                        </tr>
-                    }
-
-                    @if (Model.QuoteRequest?.NeedsSpotColorPlateChange == true && Model.AdditionalCharges.TryGetValue("SpotColorPlateChange", out var spotColorPlateChangeCharge))
-                    {
-                        var plateChangeQty = Model.QuoteRequest.SpotColorPlateChangeQuantity ?? 1;
-                        var totalPlateChangePrice = spotColorPlateChangeCharge.Price * plateChangeQty;
-                        <tr style="background: #fef9c3;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #854d0e;">🎨</span> Spot Color Plate/Copy Change
-                                <br />
-                                <small style="color: #713f12; font-weight: normal;">
-                                    @plateChangeQty × @FormatCurrency(spotColorPlateChangeCharge.Price) @(spotColorPlateChangeCharge.Unit)
-                                </small>
-                            </td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(totalPlateChangePrice)</td>
-                            <td style="font-weight: 600;">total</td>
-                        </tr>
-                    }
-
-                    @if (!hasAnyCharges)
-                    {
-                        <tr>
-                            <td colspan="3" style="text-align:center; color:#94a3b8; font-style:italic;">
-                                No additional charges were added to this quote.
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
-        </section>
+        @await Html.PartialAsync("_AdditionalCharges", (IReadOnlyList<WiseLabels.Models.QuoteLineItem>)(Model.QuoteRequest?.LineItems ?? new List<WiseLabels.Models.QuoteLineItem>()))
 
         @if (Model.QuoteRequest != null)
         {
@@ -615,12 +504,9 @@
                                           ("quantities",                   q.Quantities != null ? string.Join(", ", q.Quantities) : null) }),
                 ("Artwork",       new[] { ("artworkOption",                q.ArtworkOption),
                                           ("artworkOptionValue",           q.ArtworkOptionValue) }),
-                ("Press Proof",   new[] { ("needsPressProof",              q.NeedsPressProof.ToString().ToLower()),
-                                          ("pressProofQuantity",           q.PressProofQuantity?.ToString()) }),
-                ("Spot Color",    new[] { ("needsSpotColorPlateChange",    q.NeedsSpotColorPlateChange.ToString().ToLower()),
-                                          ("spotColorPlateChangeQty",      q.SpotColorPlateChangeQuantity?.ToString()) }),
-                ("Color Changes", new[] { ("colorChanges",                 q.ColorChanges?.ToString()),
-                                          ("digitalVersionChanges",        q.DigitalVersionChanges?.ToString()) }),
+                ("Line Items",    new[] { ("selectedCount",                 (q.LineItems?.Count(li => li.Selected) ?? 0).ToString()),
+                                          ("chargesTotal",                 WiseLabels.Models.LineItemPricing.TotalOf(q.LineItems).ToString("C2")),
+                                          ("itemRefs",                     string.Join(", ", (q.LineItems ?? new List<WiseLabels.Models.QuoteLineItem>()).Where(li => li.Selected).Select(li => li.ItemRef))) }),
                 ("File",          new[] { ("uploadedFileName",             q.UploadedFileName),
                                           ("uploadedFileOriginalName",     q.UploadedFileOriginalName),
                                           ("uploadedFileSize",             q.UploadedFileSize?.ToString()) }),
@@ -744,4 +630,3 @@
 </script>
 
 <script src="~/js/site.js"></script>
-<script src="~/js/submit.js" asp-append-version="true"></script>

--- a/Pages/Confirm.cshtml.cs
+++ b/Pages/Confirm.cshtml.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using WiseLabels.Models;
 using System.Text.Json;
@@ -7,20 +7,13 @@ using Microsoft.Data.SqlClient;
 
 namespace WiseLabels.Pages
 {
-    public class LineItemCharge
-    {
-        public string ItemRef { get; set; } = string.Empty;
-        public string Description { get; set; } = string.Empty;
-        public decimal Price { get; set; }
-        public string Unit { get; set; } = string.Empty;
-    }
-
     public class ConfirmModel : PageModel
     {
         private readonly ILogger<ConfirmModel> _logger;
         private readonly WiseLabels.Services.IQuoteService _quoteService;
         private readonly WiseLabels.Services.IEmailService _emailService;
         private readonly WiseLabels.Services.ICustomerContactService _customerContactService;
+        private readonly WiseLabels.Services.ILineItemCatalogService _lineItemCatalog;
         private readonly IConfiguration _configuration;
 
         public ConfirmModel(
@@ -28,12 +21,14 @@ namespace WiseLabels.Pages
             WiseLabels.Services.IQuoteService quoteService, 
             WiseLabels.Services.IEmailService emailService,
             WiseLabels.Services.ICustomerContactService customerContactService,
+            WiseLabels.Services.ILineItemCatalogService lineItemCatalog,
             IConfiguration configuration)
         {
             _logger = logger;
             _quoteService = quoteService;
             _emailService = emailService;
             _customerContactService = customerContactService;
+            _lineItemCatalog = lineItemCatalog;
             _configuration = configuration;
         }
 
@@ -43,7 +38,6 @@ namespace WiseLabels.Pages
         public string? ApiPayloadJson { get; set; }
         public string? FormValuesJson { get; set; }
         public List<QuotePriceBreakdown> PriceBreakdown { get; } = new();
-        public Dictionary<string, LineItemCharge> AdditionalCharges { get; set; } = new();
 
         public async Task OnGetAsync()
         {
@@ -55,6 +49,7 @@ namespace WiseLabels.Pages
                 {
                     var quoteJson = Convert.ToString(quoteData) ?? "{}";
                     QuoteRequest = JsonSerializer.Deserialize<QuoteRequest>(quoteJson) ?? new QuoteRequest();
+                    QuoteRequestCompat.UpgradeLegacyLineItems(QuoteRequest);
                     // Keep the original JSON in TempData so it's available for Edit redirect
                     TempData["QuoteRequest"] = quoteJson;
                 }
@@ -69,125 +64,30 @@ namespace WiseLabels.Pages
             await LoadLineItemPricesAsync();
         }
 
+        /// <summary>
+        /// Re-prices the quote's line items against the CERM price list.
+        /// Prices are never taken from the posted form - see
+        /// <see cref="WiseLabels.Services.ILineItemCatalogService.ResolvePostedAsync"/>.
+        /// </summary>
         private async Task LoadLineItemPricesAsync()
         {
-            // Load line item prices based on quote requirements
-            if (QuoteRequest?.IsCustomDie == true)
-            {
-                _logger.LogInformation(
-                    "Custom die detected. IsCustomDie={IsCustomDie}, DieSizeInfo={DieSizeInfo}",
-                    QuoteRequest.IsCustomDie,
-                    QuoteRequest.DieSizeInfo ?? "NULL");
+            if (QuoteRequest == null) return;
 
-                await LoadLineItemPriceAsync("100001", "CustomDie");
-            }
+            var context = new WiseLabels.Services.LineItemContext(
+                CustomerId: QuoteRequest.CustomerId,
+                PrintingId: QuoteRequest.PrintingValue,
+                ShapeValue: QuoteRequest.ShapeValue,
+                CornersValue: QuoteRequest.CornersValue,
+                IsCustomDie: QuoteRequest.IsCustomDie,
+                HasExistingDie: !string.IsNullOrWhiteSpace(QuoteRequest.CuttingDieValue)
+                                || !string.IsNullOrWhiteSpace(QuoteRequest.CuttingDie));
 
-            // Load color changes line item if spot printing with color changes
-            if (QuoteRequest?.ColorChanges > 0)
-            {
-                _logger.LogInformation(
-                    "Color changes detected. ColorChanges={ColorChanges}",
-                    QuoteRequest.ColorChanges);
+            QuoteRequest.LineItems = await _lineItemCatalog.ResolvePostedAsync(context, QuoteRequest.LineItems);
 
-                await LoadLineItemPriceAsync("100018", "ColorChanges");
-            }
-
-            // Load digital version changes line item if process color printing with version changes
-            if (QuoteRequest?.DigitalVersionChanges > 0)
-            {
-                _logger.LogInformation(
-                    "Digital version changes detected. DigitalVersionChanges={DigitalVersionChanges}",
-                    QuoteRequest.DigitalVersionChanges);
-
-                await LoadLineItemPriceAsync("100035", "DigitalVersionChanges");
-            }
-
-            // Load press proof line item if requested
-            if (QuoteRequest?.NeedsPressProof == true)
-            {
-                _logger.LogInformation(
-                    "Press proof requested. Quantity={PressProofQuantity}",
-                    QuoteRequest.PressProofQuantity);
-
-                await LoadLineItemPriceAsync("100031", "PressProof");
-            }
-
-            // Load spot color plate change line item if requested
-            if (QuoteRequest?.NeedsSpotColorPlateChange == true)
-            {
-                _logger.LogInformation(
-                    "Spot color plate change requested. Quantity={SpotColorPlateChangeQuantity}",
-                    QuoteRequest.SpotColorPlateChangeQuantity);
-
-                await LoadLineItemPriceAsync("100017", "SpotColorPlateChange");
-            }
-
-            // Easy to add more line items in the future:
-            // await LoadLineItemPriceAsync("100002", "SetupCharge");
-            // await LoadLineItemPriceAsync("100003", "PlateCharge");
-        }
-
-        private async Task LoadLineItemPriceAsync(string itemRef, string chargeKey)
-        {
-            try
-            {
-                var connectionString = _configuration.GetConnectionString("CermDatabase");
-                if (string.IsNullOrEmpty(connectionString))
-                {
-                    _logger.LogError("CermDatabase connection string not found");
-                    return;
-                }
-
-                // Query stdfpl__ table directly (like CuttingDie does with stnspr__)
-                var sql = @"
-                    SELECT TOP 1 
-                        fpl__ref,
-                        fpl__rpn,
-                        fkttxt11,
-                        prijs_bm,
-                        omsaant1
-                    FROM stdfpl__ 
-                    WHERE fpl__ref = @itemRef 
-                        AND (geblokk_ IS NULL OR geblokk_ != '1')";
-
-                using (var connection = new SqlConnection(connectionString))
-                {
-                    await connection.OpenAsync();
-
-                    using (var command = new SqlCommand(sql, connection))
-                    {
-                        command.Parameters.AddWithValue("@itemRef", itemRef);
-
-                        using (var reader = await command.ExecuteReaderAsync())
-                        {
-                            if (await reader.ReadAsync())
-                            {
-                                var charge = new LineItemCharge
-                                {
-                                    ItemRef = reader.IsDBNull(0) ? string.Empty : reader.GetString(0),
-                                    Description = reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
-                                    Price = reader.IsDBNull(3) ? 0 : (decimal)reader.GetDouble(3),
-                                    Unit = reader.IsDBNull(4) ? "each" : reader.GetString(4).Trim()
-                                };
-
-                                AdditionalCharges[chargeKey] = charge;
-
-                                _logger.LogInformation(
-                                    "Loaded line item {ItemRef} ({Key}): {Price} {Unit} - {Description}",
-                                    itemRef, chargeKey, charge.Price, charge.Unit, charge.Description);
-                            }
-                            else
-                            {
-                                _logger.LogWarning("Line item {ItemRef} not found in stdfpl__ table", itemRef);
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error loading line item price for {ItemRef}", itemRef);
-            }
+            _logger.LogInformation(
+                "Resolved {Count} line item(s) totalling {Total:C2} for the quote.",
+                QuoteRequest.LineItems.Count,
+                LineItemPricing.TotalOf(QuoteRequest.LineItems));
         }
 
         public async Task<IActionResult> OnPostConfirmAsync()
@@ -208,6 +108,7 @@ namespace WiseLabels.Pages
                 {
                     return RedirectToPage("/Index");
                 }
+                QuoteRequestCompat.UpgradeLegacyLineItems(quote);
 
                 // Load the quote request into the property so LoadLineItemPricesAsync can access it
                 QuoteRequest = quote;
@@ -273,41 +174,6 @@ namespace WiseLabels.Pages
                     TempData["CermApiResponse"] = cermResponseJson;
                 if (!string.IsNullOrWhiteSpace(ApiPayloadJson))
                     TempData["CermApiRequest"] = ApiPayloadJson;
-
-                // Pass line item charges to Success page
-                if (AdditionalCharges.TryGetValue("CustomDie", out var customDieCharge))
-                {
-                    TempData["CustomDiePrice"] = customDieCharge.Price.ToString();
-                    TempData["CustomDieUnit"] = customDieCharge.Unit;
-                }
-
-                if (AdditionalCharges.TryGetValue("ColorChanges", out var colorChangesCharge))
-                {
-                    TempData["ColorChangesPrice"] = colorChangesCharge.Price.ToString();
-                    TempData["ColorChangesUnit"] = colorChangesCharge.Unit;
-                    TempData["ColorChangesQty"] = QuoteRequest.ColorChanges?.ToString() ?? "0";
-                }
-
-                if (AdditionalCharges.TryGetValue("DigitalVersionChanges", out var digitalVersionChangesCharge))
-                {
-                    TempData["DigitalVersionChangesPrice"] = digitalVersionChangesCharge.Price.ToString();
-                    TempData["DigitalVersionChangesUnit"] = digitalVersionChangesCharge.Unit;
-                    TempData["DigitalVersionChangesQty"] = QuoteRequest.DigitalVersionChanges?.ToString() ?? "0";
-                }
-
-                if (AdditionalCharges.TryGetValue("PressProof", out var pressProofCharge))
-                {
-                    TempData["PressProofPrice"] = pressProofCharge.Price.ToString();
-                    TempData["PressProofUnit"] = pressProofCharge.Unit;
-                    TempData["PressProofQty"] = QuoteRequest.PressProofQuantity?.ToString() ?? "1";
-                }
-
-                if (AdditionalCharges.TryGetValue("SpotColorPlateChange", out var spotColorPlateChangeCharge))
-                {
-                    TempData["SpotColorPlateChangePrice"] = spotColorPlateChangeCharge.Price.ToString();
-                    TempData["SpotColorPlateChangeUnit"] = spotColorPlateChangeCharge.Unit;
-                    TempData["SpotColorPlateChangeQty"] = QuoteRequest.SpotColorPlateChangeQuantity?.ToString() ?? "1";
-                }
 
                 if (string.IsNullOrWhiteSpace(cermCalculationId) && string.IsNullOrWhiteSpace(cermEstimateId))
                 {
@@ -402,8 +268,10 @@ namespace WiseLabels.Pages
                     _logger.LogWarning("No quote data found to preserve for edit - TempData is empty and QuoteRequest is null/empty");
                 }
             }
-            
-            return RedirectToPage("/Index");
+
+            // Edit must return to the quote form; /Index is the dashboard and cannot
+            // consume the preserved TempData.
+            return RedirectToPage("/GetQuote");
         }
 
         private void LoadPriceBreakdown()

--- a/Pages/GetQuote.cshtml
+++ b/Pages/GetQuote.cshtml
@@ -316,101 +316,7 @@
                 <div id="printing-error" class="form-text text-danger d-none"></div>
             </div>
 
-            <div class="mb-4 d-none" id="line-items-section">
-                <h5 class="form-label fw-semibold mb-3">Line Items</h5>
-                <div class="border rounded p-3">
-                    @if (Model.SavedQuoteRequest != null)
-                    {
-                        <div class="alert alert-warning alert-sm mb-3 d-none" role="alert" id="line-items-warning-alert">
-                            <strong>?? Action Required:</strong> Please review and fill out the line item fields below based on your quote requirements.
-                        </div>
-                    }
-
-                    <div class="mb-3 d-none" id="color-changes-section">
-                        <label for="color-changes" class="form-label fw-semibold">Number of Color Changes</label>
-                        <input 
-                            type="number" 
-                            class="form-control" 
-                            id="color-changes"
-                            name="colorChanges"
-                            min="0"
-                            step="1"
-                            placeholder="Enter number of color changes"
-                            value="@(Model.SavedQuoteRequest?.ColorChanges?.ToString() ?? string.Empty)">
-                        <div class="form-text">Enter the number of color changes needed for this job. Each change will be charged separately.</div>
-                    </div>
-
-                    <div class="mb-3 d-none" id="digital-version-changes-section">
-                        <label for="digital-version-changes" class="form-label fw-semibold">Number of Digital Full Color Version Changes</label>
-                        <input 
-                            type="number" 
-                            class="form-control" 
-                            id="digital-version-changes"
-                            name="digitalVersionChanges"
-                            min="0"
-                            step="1"
-                            placeholder="Enter number of version changes"
-                            value="@(Model.SavedQuoteRequest?.DigitalVersionChanges?.ToString() ?? string.Empty)">
-                        <div class="form-text">Enter the number of version changes needed for this digital job. Each version change will be charged separately.</div>
-                    </div>
-
-                    <div class="mb-3">
-                        <div class="form-check">
-                            <input 
-                                class="form-check-input" 
-                                type="checkbox" 
-                                id="needs-press-proof"
-                                name="needsPressProof"
-                                value="true"
-                                @(Model.SavedQuoteRequest?.NeedsPressProof == true ? "checked" : "")>
-                            <label class="form-check-label" for="needs-press-proof">
-                                Press Proof - Print Only, Not Die Cut
-                            </label>
-                        </div>
-                        <div class="mt-2 d-none" id="press-proof-quantity-section">
-                            <label for="press-proof-quantity" class="form-label">Press Proof Quantity</label>
-                            <input 
-                                type="number" 
-                                class="form-control" 
-                                id="press-proof-quantity"
-                                name="pressProofQuantity"
-                                min="1"
-                                step="1"
-                                placeholder="1"
-                                value="@(Model.SavedQuoteRequest?.PressProofQuantity ?? 1)">
-                            <div class="form-text">Enter the quantity for the press proof.</div>
-                        </div>
-                    </div>
-
-                    <div class="mb-0">
-                        <div class="form-check">
-                            <input 
-                                class="form-check-input" 
-                                type="checkbox" 
-                                id="needs-spot-color-plate-change"
-                                name="needsSpotColorPlateChange"
-                                value="true"
-                                @(Model.SavedQuoteRequest?.NeedsSpotColorPlateChange == true ? "checked" : "")>
-                            <label class="form-check-label" for="needs-spot-color-plate-change">
-                                Spot Color Plate/Copy Change
-                            </label>
-                        </div>
-                        <div class="mt-2 d-none" id="spot-color-plate-change-quantity-section">
-                            <label for="spot-color-plate-change-quantity" class="form-label">Plate/Copy Change Quantity</label>
-                            <input 
-                                type="number" 
-                                class="form-control" 
-                                id="spot-color-plate-change-quantity"
-                                name="spotColorPlateChangeQuantity"
-                                min="1"
-                                step="1"
-                                placeholder="1"
-                                value="@(Model.SavedQuoteRequest?.SpotColorPlateChangeQuantity ?? 1)">
-                            <div class="form-text">Enter the quantity for plate/copy changes.</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            @await Html.PartialAsync("_LineItemsEditor", (IReadOnlyList<WiseLabels.Models.QuoteLineItem>)Model.LineItemCatalog)
 
             <div class="mb-4" id="finish-section">
                 <div class="d-flex align-items-center gap-2 mb-1">
@@ -694,9 +600,7 @@
                 'Unwind':        ['unwindDirection','unwindDirectionValue'],
                 'Quantities':    ['totalQuantity','quantity'],
                 'Artwork':       ['artworkOption','artworkOptionValue'],
-                'Press Proof':   ['needsPressProof','pressProofQuantity'],
-                'Spot Color':    ['needsSpotColorPlateChange','spotColorPlateChangeQuantity'],
-                'Color Changes': ['colorChanges','digitalVersionChanges'],
+                'Line Items':    ['lineItemsJson'],
             };
             const GROUP_CLASSES = {
                 Customer:'table-primary', Shape:'table-info', Dimensions:'table-info',
@@ -937,49 +841,6 @@
             </div>
         }
 
-        <script>
-            // Toggle Press Proof quantity section
-            (function() {
-                const checkbox = document.getElementById('needs-press-proof');
-                const quantitySection = document.getElementById('press-proof-quantity-section');
-
-                if (checkbox && quantitySection) {
-                    checkbox.addEventListener('change', function() {
-                        if (this.checked) {
-                            quantitySection.classList.remove('d-none');
-                        } else {
-                            quantitySection.classList.add('d-none');
-                        }
-                    });
-
-                    // Initialize on page load
-                    if (checkbox.checked) {
-                        quantitySection.classList.remove('d-none');
-                    }
-                }
-            })();
-
-            // Toggle Spot Color Plate Change quantity section
-            (function() {
-                const checkbox = document.getElementById('needs-spot-color-plate-change');
-                const quantitySection = document.getElementById('spot-color-plate-change-quantity-section');
-
-                if (checkbox && quantitySection) {
-                    checkbox.addEventListener('change', function() {
-                        if (this.checked) {
-                            quantitySection.classList.remove('d-none');
-                        } else {
-                            quantitySection.classList.add('d-none');
-                        }
-                    });
-
-                    // Initialize on page load
-                    if (checkbox.checked) {
-                        quantitySection.classList.remove('d-none');
-                    }
-                }
-            })();
-        </script>
 
         <script>
             function formatFileSize(bytes) {
@@ -1470,130 +1331,6 @@
                 }
             })();
 
-            (function () {
-                const colorChangesSection = document.getElementById('color-changes-section');
-                const colorChangesInput = document.getElementById('color-changes');
-                const digitalVersionChangesSection = document.getElementById('digital-version-changes-section');
-                const digitalVersionChangesInput = document.getElementById('digital-version-changes');
-                const lineItemsSection = document.getElementById('line-items-section');
-                const lineItemsWarningAlert = document.getElementById('line-items-warning-alert');
-                const pressProofCheckbox = document.getElementById('needs-press-proof');
-                const pressProofQuantityInput = document.getElementById('press-proof-quantity');
-                const spotColorCheckbox = document.getElementById('needs-spot-color-plate-change');
-                const spotColorQuantityInput = document.getElementById('spot-color-plate-change-quantity');
-
-                if (!colorChangesSection || !colorChangesInput || !digitalVersionChangesSection || !digitalVersionChangesInput || !lineItemsSection) {
-                    console.warn('Missing printing-dependent field elements');
-                    return;
-                }
-
-                let userHasInteracted = false;
-
-                function removeLineItemsAttention() {
-                    if (!lineItemsSection) return;
-
-                    userHasInteracted = true;
-                    lineItemsSection.classList.remove('needs-attention');
-                    if (lineItemsWarningAlert) {
-                        lineItemsWarningAlert.classList.add('d-none');
-                    }
-                }
-
-                function checkLineItemsAttention() {
-                    // Check if we're from a saved quote
-                    const savedQuoteElement = document.getElementById('saved-quote-data');
-                    if (!savedQuoteElement || !lineItemsSection) {
-                        return;
-                    }
-
-                    // Check if line items section is visible
-                    if (lineItemsSection.classList.contains('d-none')) {
-                        return;
-                    }
-
-                    // If user has already interacted with any field, don't re-apply highlighting
-                    if (userHasInteracted) {
-                        return;
-                    }
-
-                    // Check if any visible numeric inputs have no value or are still at the default 0 (not user-entered)
-                    // Only highlight if the fields appear to be untouched
-                    const colorChangesUntouched = !colorChangesSection.classList.contains('d-none') && !colorChangesInput.value;
-                    const digitalVersionUntouched = !digitalVersionChangesSection.classList.contains('d-none') && !digitalVersionChangesInput.value;
-                    const hasUntouchedFields = colorChangesUntouched || digitalVersionUntouched;
-
-                    if (hasUntouchedFields) {
-                        lineItemsSection.classList.add('needs-attention');
-                        if (lineItemsWarningAlert) {
-                            lineItemsWarningAlert.classList.remove('d-none');
-                        }
-                    } else {
-                        lineItemsSection.classList.remove('needs-attention');
-                        if (lineItemsWarningAlert) {
-                            lineItemsWarningAlert.classList.add('d-none');
-                        }
-                    }
-                }
-
-                function updatePrintingDependentFields(printingLabel) {
-                    const labelLower = (printingLabel || '').toLowerCase();
-                    const isSpotPrinting = labelLower.includes('spot');
-                    const isProcessColor = labelLower.includes('process') && labelLower.includes('color');
-
-                    console.log('Printing selection:', printingLabel, '| Spot:', isSpotPrinting, '| Process Color:', isProcessColor);
-
-                    // Show/hide color changes for spot printing
-                    colorChangesSection.classList.toggle('d-none', !isSpotPrinting);
-                    if (!isSpotPrinting) {
-                        colorChangesInput.value = ''; // Clear instead of setting to 0
-                    }
-
-                    // Show/hide digital version changes for process color
-                    digitalVersionChangesSection.classList.toggle('d-none', !isProcessColor);
-                    if (!isProcessColor) {
-                        digitalVersionChangesInput.value = ''; // Clear instead of setting to 0
-                    }
-
-                    // Show line items section if any subsection is visible
-                    const hasVisibleLineItems = isSpotPrinting || isProcessColor;
-                    lineItemsSection.classList.toggle('d-none', !hasVisibleLineItems);
-
-                    // Check if we need attention styling (only if user hasn't interacted yet)
-                    checkLineItemsAttention();
-                }
-
-                // Remove highlighting on ANY interaction with line items fields
-                colorChangesInput.addEventListener('input', removeLineItemsAttention);
-                colorChangesInput.addEventListener('change', removeLineItemsAttention);
-                digitalVersionChangesInput.addEventListener('input', removeLineItemsAttention);
-                digitalVersionChangesInput.addEventListener('change', removeLineItemsAttention);
-
-                if (pressProofCheckbox) {
-                    pressProofCheckbox.addEventListener('change', removeLineItemsAttention);
-                }
-                if (pressProofQuantityInput) {
-                    pressProofQuantityInput.addEventListener('input', removeLineItemsAttention);
-                    pressProofQuantityInput.addEventListener('change', removeLineItemsAttention);
-                }
-                if (spotColorCheckbox) {
-                    spotColorCheckbox.addEventListener('change', removeLineItemsAttention);
-                }
-                if (spotColorQuantityInput) {
-                    spotColorQuantityInput.addEventListener('input', removeLineItemsAttention);
-                    spotColorQuantityInput.addEventListener('change', removeLineItemsAttention);
-                }
-
-                // Listen for printing selection changes
-                window.addEventListener('printingSelectionChanged', event => {
-                    updatePrintingDependentFields(event.detail?.label || '');
-                });
-
-                // Check initial state
-                const printingInput = document.getElementById('printing-input');
-                if (printingInput && printingInput.value) {
-                    updatePrintingDependentFields(printingInput.value);
-                }
-            })();
 
             (function () {
                 const finishSelect = document.getElementById('finish-select');
@@ -2285,6 +2022,14 @@
                         const dieRadius = formatDimension(option.Radius__ ?? option.radius__ ?? '');
                         return dieRadius === radiusValue;
                     });
+
+                    // Keep the hidden die fields in step with the rectangular path. This
+                    // block previously updated only the warning banner, so a circular
+                    // custom die was never flagged and therefore never charged.
+                    const isCustomDieInput = document.getElementById('is-custom-die');
+                    const dieSizeInfoInput = document.getElementById('die-size-info');
+                    if (dieSizeInfoInput) dieSizeInfoInput.value = `${radiusValue}" dia.`;
+                    if (isCustomDieInput) isCustomDieInput.value = hasMatchingDie ? 'false' : 'true';
 
                     if (!hasMatchingDie && customDieWarningRadius && customRadiusSpan) {
                         customRadiusSpan.textContent = `${radiusValue}"`;
@@ -3103,6 +2848,7 @@
 </style>
 
 @section Scripts {
+<script src="~/js/line-items.js" asp-append-version="true"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
 <script>

--- a/Pages/GetQuote.cshtml.cs
+++ b/Pages/GetQuote.cshtml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json;
 using CERM.DataAccess;
 using CERM.DataAccess.Models;
@@ -20,13 +20,15 @@ namespace WiseLabels.Pages
         private readonly CermDbContext _context;
         private readonly IConfiguration _configuration;
         private readonly IQuoteService _quoteService;
+        private readonly ILineItemCatalogService _lineItemCatalog;
 
-        public GetQuoteModel(ILogger<GetQuoteModel> logger, CermDbContext context, IConfiguration configuration, IQuoteService quoteService)
+        public GetQuoteModel(ILogger<GetQuoteModel> logger, CermDbContext context, IConfiguration configuration, IQuoteService quoteService, ILineItemCatalogService lineItemCatalog)
         {
             _logger = logger;
             _context = context;
             _configuration = configuration;
             _quoteService = quoteService;
+            _lineItemCatalog = lineItemCatalog;
             PrintingFinishFilters = _configuration
                 .GetSection("QuoteOptions:PrintingFinishFilters")
                 .Get<Dictionary<string, string[]>>()
@@ -41,6 +43,49 @@ namespace WiseLabels.Pages
         public string? ApiRequestJson { get; set; }
         /// <summary>JSON response from CERM API (for debugging on error).</summary>
         public string? ApiResponseJson { get; set; }
+        /// <summary>Charges offered for this quote, with rule-driven pre-selection applied.</summary>
+        public IReadOnlyList<QuoteLineItem> LineItemCatalog { get; private set; } = Array.Empty<QuoteLineItem>();
+
+        /// <summary>
+        /// Loads the charge catalogue for the current form state, merging in any
+        /// selections carried by a saved quote so an edited quote round-trips.
+        /// </summary>
+        private async Task LoadLineItemCatalogAsync()
+        {
+            var context = new LineItemContext(
+                CustomerId: SavedQuoteRequest?.CustomerId,
+                PrintingId: SavedQuoteRequest?.PrintingValue,
+                ShapeValue: SavedQuoteRequest?.ShapeValue,
+                CornersValue: SavedQuoteRequest?.CornersValue,
+                IsCustomDie: SavedQuoteRequest?.IsCustomDie ?? false,
+                HasExistingDie: !string.IsNullOrWhiteSpace(SavedQuoteRequest?.CuttingDieValue)
+                                || !string.IsNullOrWhiteSpace(SavedQuoteRequest?.CuttingDie));
+
+            LineItemCatalog = await _lineItemCatalog.GetCatalogAsync(context, SavedQuoteRequest?.LineItems);
+        }
+
+        /// <summary>
+        /// Reads the line item grid's single JSON field. Only selection and quantity are
+        /// taken from it; everything price-bearing is re-resolved from CERM.
+        /// </summary>
+        private List<QuoteLineItem> ParseLineItemsFromForm(IFormCollection form)
+        {
+            var json = form["lineItemsJson"].ToString();
+            if (string.IsNullOrWhiteSpace(json)) return new List<QuoteLineItem>();
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<QuoteLineItem>>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                }) ?? new List<QuoteLineItem>();
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Could not parse posted line items; the quote will be priced without charges.");
+                return new List<QuoteLineItem>();
+            }
+        }
 
         public async Task OnGetAsync()
         {
@@ -115,6 +160,7 @@ namespace WiseLabels.Pages
             {
                 SavedQuoteRequest = chatQuoteData;
                 _logger.LogInformation("Prepopulating quote form from chat data");
+                await LoadLineItemCatalogAsync();
                 return;
             }
 
@@ -125,6 +171,7 @@ namespace WiseLabels.Pages
                 {
                     var quoteJson = Convert.ToString(quoteData) ?? "{}";
                     SavedQuoteRequest = JsonSerializer.Deserialize<QuoteRequest>(quoteJson);
+                    QuoteRequestCompat.UpgradeLegacyLineItems(SavedQuoteRequest);
                     TempData.Keep("QuoteRequest");
                 }
                 catch (Exception ex)
@@ -172,6 +219,8 @@ namespace WiseLabels.Pages
             {
                 SavedQuoteRequest = selectedQuote;
             }
+
+            await LoadLineItemCatalogAsync();
         }
 
         public async Task<IActionResult> OnPostSubmitAsync()
@@ -194,7 +243,8 @@ namespace WiseLabels.Pages
                     if (artworkFile.Length > maxFileSize)
                     {
                         ModelState.AddModelError(string.Empty, "File size exceeds 50 MB limit.");
-                        SavedQuoteRequest = BuildQuoteRequestFromForm(form);
+                        SavedQuoteRequest = BuildQuoteRequest(form);
+                        await LoadLineItemCatalogAsync();
                         return Page();
                     }
 
@@ -228,18 +278,14 @@ namespace WiseLabels.Pages
                 {
                     _logger.LogError(ex, "Error uploading file");
                     ModelState.AddModelError(string.Empty, "Failed to upload file. Please try again.");
-                    SavedQuoteRequest = BuildQuoteRequestFromForm(form);
+                    SavedQuoteRequest = BuildQuoteRequest(form);
+                    await LoadLineItemCatalogAsync();
                     return Page();
                 }
             }
 
-            var materialId = GetFormValue(form, "material", "materialValue");
-            var materialLabel = GetFormValue(form, "materialDisplay", "materialLabel");
-            var rawShapeValue = GetFormValue(form, "shapeValue", "shapeKey");
-            var shapeLabel = form["shape"].ToString();
-            var resolvedShapeValue = ResolveShapeOutline(rawShapeValue, shapeLabel);
-
-            // Load customer info from form fields (hidden inputs carry the values through POST)
+            // Customer resolution has a session side effect (it clears the stashed
+            // selection), so it stays on the submit path and is passed into the builder.
             var customerId = form["customerId"].ToString();
             var customerDisplayName = form["customerDisplayName"].ToString();
             if (string.IsNullOrWhiteSpace(customerId))
@@ -253,57 +299,14 @@ namespace WiseLabels.Pages
                 LoadSelectedQuoteFromSession(); // clear session
             }
 
-            var quoteRequest = new QuoteRequest
-            {
-                CustomerId = customerId,
-                CustomerDisplayName = customerDisplayName,
-                Name = GetFormValue(form, "name", "contactName"),
-                Company = GetFormValue(form, "company", "contactCompany"),
-                Email = GetFormValue(form, "email", "contactEmail"),
-                Phone = GetFormValue(form, "phone", "contactPhone"),
-                Comments = GetFormValue(form, "comments", "contactComments"),
-                ReferenceType = form["referenceType"].ToString().Trim(),
-                ReferenceValue = form["referenceValue"].ToString().Trim(),
-                Description = TruncateDescription(form["description"].ToString()),
-                Shape = shapeLabel,
-                LabelWidth = form["labelWidth"].ToString(),
-                LabelHeight = form["labelHeight"].ToString(),
-                Diameter = form["diameter"].ToString(),
-                Corners = form["corners"].ToString(),
-                CuttingDie = form["existingDie"].ToString(),
-                DieSizeInfo = form["dieSizeInfo"].ToString(),
-                IsCustomDie = form["isCustomDie"].ToString().Equals("true", StringComparison.OrdinalIgnoreCase),
-                ColorChanges = int.TryParse(form["colorChanges"].ToString(), out var colorChanges) ? colorChanges : (int?)null,
-                DigitalVersionChanges = int.TryParse(form["digitalVersionChanges"].ToString(), out var digitalVersionChanges) ? digitalVersionChanges : (int?)null,
-                NeedsPressProof = form["needsPressProof"].ToString().Equals("true", StringComparison.OrdinalIgnoreCase),
-                PressProofQuantity = int.TryParse(form["pressProofQuantity"].ToString(), out var pressProofQuantity) ? pressProofQuantity : (int?)null,
-                NeedsSpotColorPlateChange = form["needsSpotColorPlateChange"].ToString().Equals("true", StringComparison.OrdinalIgnoreCase),
-                SpotColorPlateChangeQuantity = int.TryParse(form["spotColorPlateChangeQuantity"].ToString(), out var spotColorPlateChangeQuantity) ? spotColorPlateChangeQuantity : (int?)null,
-                Printing = form["printing"].ToString(),
-                Material = string.IsNullOrEmpty(materialLabel) ? materialId : materialLabel,
-                ColorCode = form["colorCode"].ToString(),
-                Finish = form["finish"].ToString(),
-                PackingProcedure = form["packingProcedure"].ToString(),
-                ApplicationMethod = form["applicationMethod"].ToString(),
-                UnwindDirection = form["unwindDirection"].ToString(),
-                TotalQuantity = form["totalQuantity"].ToString(),
-                Quantities = ParseQuantitiesFromForm(form),
-                ArtworkOption = form["artworkOption"].ToString(),
-                ShapeValue = resolvedShapeValue,
-                CornersValue = form["cornersValue"].ToString(),
-                MaterialValue = materialId,
-                ColorCodeValue = form["colorCodeValue"].ToString(),
-                FinishValue = form["finishValue"].ToString(),
-                ApplicationMethodValue = form["applicationMethodValue"].ToString(),
-                UnwindDirectionValue = form["unwindDirectionValue"].ToString(),
-                ArtworkOptionValue = form["artworkOptionValue"].ToString(),
-                CuttingDieValue = form["cuttingDieValue"].ToString(),
-                PrintingValue = form["printingValue"].ToString(),
-                UploadedFileName = uploadedFileName,
-                UploadedFileOriginalName = uploadedFileOriginalName,
-                UploadedFileContentType = uploadedFileContentType,
-                UploadedFileSize = uploadedFileSize
-            };
+            var quoteRequest = BuildQuoteRequest(
+                form,
+                customerId,
+                customerDisplayName,
+                uploadedFileName,
+                uploadedFileOriginalName,
+                uploadedFileContentType,
+                uploadedFileSize);
 
             // Log the JSON request being submitted
             var jsonRequest = JsonSerializer.Serialize(quoteRequest, new JsonSerializerOptions 
@@ -341,6 +344,7 @@ namespace WiseLabels.Pages
             if (!ModelState.IsValid)
             {
                 SavedQuoteRequest = quoteRequest;
+                await LoadLineItemCatalogAsync();
                 return Page();
             }
 
@@ -359,6 +363,7 @@ namespace WiseLabels.Pages
                 });
                 ApiResponseJson = pricingResult.ResponseJson;
 
+                await LoadLineItemCatalogAsync();
                 return Page();
             }
 
@@ -454,6 +459,7 @@ namespace WiseLabels.Pages
             try
             {
                 var selection = JsonSerializer.Deserialize<QuoteRequest>(value);
+                QuoteRequestCompat.UpgradeLegacyLineItems(selection);
                 HttpContext.Session.Remove(SessionKeys.SelectedQuote);
                 return selection;
             }
@@ -548,22 +554,84 @@ namespace WiseLabels.Pages
             };
         }
 
-        private QuoteRequest BuildQuoteRequestFromForm(IFormCollection form)
+        /// <summary>
+        /// Builds a <see cref="QuoteRequest"/> from the posted form.
+        /// This is the single binder used by the submit path and by both file-upload
+        /// failure paths, so a validation error never silently drops fields.
+        /// </summary>
+        private QuoteRequest BuildQuoteRequest(
+            IFormCollection form,
+            string? customerId = null,
+            string? customerDisplayName = null,
+            string? uploadedFileName = null,
+            string? uploadedFileOriginalName = null,
+            string? uploadedFileContentType = null,
+            long? uploadedFileSize = null)
         {
+            var materialId = GetFormValue(form, "material", "materialValue");
+            var materialLabel = GetFormValue(form, "materialDisplay", "materialLabel");
+            var rawShapeValue = GetFormValue(form, "shapeValue", "shapeKey");
+            var shapeLabel = form["shape"].ToString();
+            var resolvedShapeValue = ResolveShapeOutline(rawShapeValue, shapeLabel);
+
+            if (string.IsNullOrWhiteSpace(customerId))
+            {
+                customerId = form["customerId"].ToString();
+            }
+            if (string.IsNullOrWhiteSpace(customerDisplayName))
+            {
+                customerDisplayName = form["customerDisplayName"].ToString();
+            }
+
             return new QuoteRequest
             {
-                Name = form["name"].ToString(),
-                Company = form["company"].ToString(),
-                Email = form["email"].ToString(),
-                Phone = form["phone"].ToString(),
-                Comments = form["comments"].ToString(),
-                Description = form["description"].ToString(),
-                Shape = form["shape"].ToString(),
+                CustomerId = customerId,
+                CustomerDisplayName = customerDisplayName,
+                Name = GetFormValue(form, "name", "contactName"),
+                Company = GetFormValue(form, "company", "contactCompany"),
+                Email = GetFormValue(form, "email", "contactEmail"),
+                Phone = GetFormValue(form, "phone", "contactPhone"),
+                Comments = GetFormValue(form, "comments", "contactComments"),
+                ReferenceType = form["referenceType"].ToString().Trim(),
+                ReferenceValue = form["referenceValue"].ToString().Trim(),
+                Description = TruncateDescription(form["description"].ToString()),
+                Shape = shapeLabel,
                 LabelWidth = form["labelWidth"].ToString(),
                 LabelHeight = form["labelHeight"].ToString(),
-                Material = form["materialDisplay"].ToString(),
+                Diameter = form["diameter"].ToString(),
+                Corners = form["corners"].ToString(),
+                CuttingDie = form["existingDie"].ToString(),
+                DieSizeInfo = form["dieSizeInfo"].ToString(),
+                IsCustomDie = form["isCustomDie"].ToString().Equals("true", StringComparison.OrdinalIgnoreCase),
                 Printing = form["printing"].ToString(),
-                Finish = form["finish"].ToString()
+                Material = string.IsNullOrEmpty(materialLabel) ? materialId : materialLabel,
+                ColorCode = form["colorCode"].ToString(),
+                Finish = form["finish"].ToString(),
+                PackingProcedure = form["packingProcedure"].ToString(),
+                // Both of these were posted by the form but never bound, so QuoteService
+                // always fell back to its Sheet/500 defaults.
+                PackingProcedureValue = form["packingProcedureValue"].ToString(),
+                PackingQuantity = int.TryParse(form["packingQuantity"].ToString(), out var packingQuantity) ? packingQuantity : (int?)null,
+                ApplicationMethod = form["applicationMethod"].ToString(),
+                UnwindDirection = form["unwindDirection"].ToString(),
+                TotalQuantity = form["totalQuantity"].ToString(),
+                Quantities = ParseQuantitiesFromForm(form),
+                LineItems = ParseLineItemsFromForm(form),
+                ArtworkOption = form["artworkOption"].ToString(),
+                ShapeValue = resolvedShapeValue,
+                CornersValue = form["cornersValue"].ToString(),
+                MaterialValue = materialId,
+                ColorCodeValue = form["colorCodeValue"].ToString(),
+                FinishValue = form["finishValue"].ToString(),
+                ApplicationMethodValue = form["applicationMethodValue"].ToString(),
+                UnwindDirectionValue = form["unwindDirectionValue"].ToString(),
+                ArtworkOptionValue = form["artworkOptionValue"].ToString(),
+                CuttingDieValue = form["cuttingDieValue"].ToString(),
+                PrintingValue = form["printingValue"].ToString(),
+                UploadedFileName = uploadedFileName,
+                UploadedFileOriginalName = uploadedFileOriginalName,
+                UploadedFileContentType = uploadedFileContentType,
+                UploadedFileSize = uploadedFileSize
             };
         }
     }

--- a/Pages/Shared/_AdditionalCharges.cshtml
+++ b/Pages/Shared/_AdditionalCharges.cshtml
@@ -1,0 +1,68 @@
+@model IReadOnlyList<WiseLabels.Models.QuoteLineItem>
+@using WiseLabels.Models
+@{
+    // One renderer for the Confirm page, the Success page and (via EmailService) the
+    // confirmation email, so the three can no longer disagree about what was quoted.
+    var charges = (Model ?? Array.Empty<QuoteLineItem>())
+        .Where(i => i.Selected)
+        .OrderBy(i => i.Order)
+        .ToList();
+    var grandTotal = LineItemPricing.TotalOf(charges);
+    string Money(decimal value) => value.ToString("C2");
+}
+
+<section class="additional-charges">
+    <h3>Additional Charges (if applicable)</h3>
+    <table>
+        <thead>
+            <tr>
+                <th style="width: 55%;">Description</th>
+                <th style="width: 15%;" class="text-right">Qty</th>
+                <th style="width: 15%;" class="text-right">Unit Price</th>
+                <th style="width: 15%;" class="text-right">Total</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if (charges.Count == 0)
+            {
+                <tr>
+                    <td colspan="4" style="text-align:center; color:#94a3b8; font-style:italic;">
+                        No additional charges were added to this quote.
+                    </td>
+                </tr>
+            }
+            else
+            {
+                foreach (var charge in charges)
+                {
+                    <tr>
+                        <td style="font-weight: 600;">
+                            @charge.Description
+                            @if (!string.IsNullOrWhiteSpace(charge.Description2))
+                            {
+                                <br />
+                                <span style="font-weight: normal;">@charge.Description2</span>
+                            }
+                            @if (LineItemPricing.IsQuantityBased(charge.PriceBasis))
+                            {
+                                <br />
+                                <small style="color:#64748b; font-weight: normal;">
+                                    @charge.Quantity.ToString("0.##") &times; @Money(charge.UnitPrice) @LineItemPricing.BasisLabel(charge.PriceBasis)
+                                </small>
+                            }
+                        </td>
+                        <td class="text-right">
+                            @(LineItemPricing.IsQuantityBased(charge.PriceBasis) ? charge.Quantity.ToString("0.##") : "—")
+                        </td>
+                        <td class="text-right">@Money(charge.UnitPrice)</td>
+                        <td class="text-right" style="font-weight: 600;">@Money(charge.Total)</td>
+                    </tr>
+                }
+                <tr>
+                    <td colspan="3" class="text-right" style="font-weight: 700;">Total additional charges</td>
+                    <td class="text-right" style="font-weight: 700;">@Money(grandTotal)</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</section>

--- a/Pages/Shared/_LineItemsEditor.cshtml
+++ b/Pages/Shared/_LineItemsEditor.cshtml
@@ -1,0 +1,100 @@
+@model IReadOnlyList<WiseLabels.Models.QuoteLineItem>
+@using WiseLabels.Models
+@{
+    var items = (Model ?? Array.Empty<QuoteLineItem>()).OrderBy(i => i.Order).ToList();
+    var serialized = System.Text.Json.JsonSerializer.Serialize(items, new System.Text.Json.JsonSerializerOptions
+    {
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+    });
+}
+
+<div class="mb-4" id="line-items-section">
+    <h5 class="form-label fw-semibold mb-1">Line Items</h5>
+    <div class="form-text mb-2">
+        Charges are proposed automatically based on your selections. Tick or untick any of
+        them and adjust the quantities.
+    </div>
+
+    @* The grid posts a single JSON field rather than parallel arrays. Unchecked
+       checkboxes are not submitted, so parallel arrays would desynchronise and attach
+       quantities to the wrong charge. *@
+    <input type="hidden" id="line-items-json" name="lineItemsJson" value="" />
+    <script id="line-items-data" type="application/json">@Html.Raw(serialized)</script>
+
+    <div class="border rounded p-3">
+        @if (items.Count == 0)
+        {
+            <div class="form-text text-muted mb-0" id="line-items-empty">
+                No additional charges are available for this quote.
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0" id="line-items-table">
+                    <thead>
+                        <tr>
+                            <th style="width:2.5rem;"></th>
+                            <th>Description</th>
+                            <th style="width:9rem;">Qty</th>
+                            <th style="width:8rem;" class="text-end">Unit Price</th>
+                            <th style="width:8rem;" class="text-end">Total</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in items)
+                        {
+                            <tr class="line-item-row"
+                                data-item-ref="@item.ItemRef"
+                                data-key="@item.Key"
+                                data-price-basis="@item.PriceBasis"
+                                data-unit-price="@item.UnitPrice.ToString(System.Globalization.CultureInfo.InvariantCulture)"
+                                data-forced="@item.Forced.ToString().ToLowerInvariant()"
+                                data-quantity-editable="@item.QuantityEditable.ToString().ToLowerInvariant()">
+                                <td>
+                                    <input class="form-check-input line-item-selected"
+                                           type="checkbox"
+                                           aria-label="Include @item.Description"
+                                           @(item.Selected ? "checked" : "")
+                                           @(item.Forced ? "disabled" : "") />
+                                </td>
+                                <td>
+                                    <span class="fw-semibold">@item.Description</span>
+                                    @if (!string.IsNullOrWhiteSpace(item.Description2))
+                                    {
+                                        <br /><small class="text-muted">@item.Description2</small>
+                                    }
+                                    @if (item.Forced)
+                                    {
+                                        <br />
+                                        <small class="text-warning-emphasis">
+                                            Required &mdash; no existing die size was selected.
+                                        </small>
+                                    }
+                                </td>
+                                <td>
+                                    <input type="number"
+                                           class="form-control form-control-sm line-item-qty"
+                                           min="0"
+                                           step="1"
+                                           value="@item.Quantity.ToString("0.##")"
+                                           @(item.QuantityEditable ? "" : "disabled") />
+                                </td>
+                                <td class="text-end line-item-unit-price">@item.UnitPrice.ToString("C2")</td>
+                                <td class="text-end fw-semibold line-item-total">@item.Total.ToString("C2")</td>
+                            </tr>
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td colspan="4" class="text-end fw-bold">Total additional charges</td>
+                            <td class="text-end fw-bold" id="line-items-total">
+                                @LineItemPricing.TotalOf(items).ToString("C2")
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        }
+    </div>
+</div>

--- a/Pages/Success.cshtml
+++ b/Pages/Success.cshtml
@@ -1,4 +1,4 @@
-@page
+﻿@page
 @model WiseLabels.Pages.SuccessModel
 @using WiseLabels.Models
 @using System.Globalization
@@ -474,122 +474,7 @@
             </tbody>
         </table>
 
-        <section class="additional-charges">
-            <h3>Additional Charges (if applicable)</h3>
-            <table>
-                <thead>
-                    <tr>
-                        <th style="width: 55%;">Description</th>
-                        <th style="width: 10%;"></th>
-                        <th style="width: 20%;" class="text-right">Price</th>
-                        <th style="width: 15%;">Units</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @* Additional line items for custom die and other charges *@
-                    @{
-                        var hasAnyCharges = Model.QuoteRequest?.IsCustomDie == true
-                            || Model.QuoteRequest?.ColorChanges > 0
-                            || Model.QuoteRequest?.DigitalVersionChanges > 0
-                            || Model.QuoteRequest?.NeedsPressProof == true
-                            || Model.QuoteRequest?.NeedsSpotColorPlateChange == true;
-                    }
-
-                    @if (Model.QuoteRequest?.IsCustomDie == true && Model.CustomDiePrice.HasValue)
-                    {
-                        <tr style="background: #fef3c7;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #92400e;">⚠️</span> Custom Die Fabrication
-                                <br />
-                                <small style="color: #78350f; font-weight: normal;">
-                                    Die Size: @FormatMaybeValue(Model.QuoteRequest?.DieSizeInfo)
-                                </small>
-                            </td>
-                            <td></td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(Model.CustomDiePrice)</td>
-                            <td style="font-weight: 600;">@(Model.CustomDieUnit ?? "each")</td>
-                        </tr>
-                    }
-
-                    @if (Model.QuoteRequest?.ColorChanges > 0 && Model.ColorChangesPrice.HasValue)
-                    {
-                        var totalColorChangePrice = Model.ColorChangesPrice.Value * (Model.ColorChangesQty ?? Model.QuoteRequest.ColorChanges.Value);
-                        <tr style="background: #dbeafe;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #1e40af;">🎨</span> Color Changes
-                                <br />
-                                <small style="color: #1e3a8a; font-weight: normal;">
-                                    @(Model.ColorChangesQty ?? Model.QuoteRequest.ColorChanges) changes × @FormatCurrency(Model.ColorChangesPrice.Value) per change
-                                </small>
-                            </td>
-                            <td></td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(totalColorChangePrice)</td>
-                            <td style="font-weight: 600;">total</td>
-                        </tr>
-                    }
-
-                    @if (Model.QuoteRequest?.DigitalVersionChanges > 0 && Model.DigitalVersionChangesPrice.HasValue)
-                    {
-                        var totalDigitalVersionChangePrice = Model.DigitalVersionChangesPrice.Value * (Model.DigitalVersionChangesQty ?? Model.QuoteRequest.DigitalVersionChanges.Value);
-                        <tr style="background: #e0e7ff;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #3730a3;">🖨️</span> Digital Full Color Version Changes
-                                <br />
-                                <small style="color: #312e81; font-weight: normal;">
-                                    @(Model.DigitalVersionChangesQty ?? Model.QuoteRequest.DigitalVersionChanges) changes × @FormatCurrency(Model.DigitalVersionChangesPrice.Value) per change
-                                </small>
-                            </td>
-                            <td></td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(totalDigitalVersionChangePrice)</td>
-                            <td style="font-weight: 600;">total</td>
-                        </tr>
-                    }
-
-                    @if (Model.QuoteRequest?.NeedsPressProof == true && Model.PressProofPrice.HasValue)
-                    {
-                        var totalPressProofPrice = Model.PressProofPrice.Value * (Model.PressProofQty ?? 1);
-                        <tr style="background: #fce7f3;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #9f1239;">📄</span> Press Proof - Print Only, Not Die Cut
-                                <br />
-                                <small style="color: #881337; font-weight: normal;">
-                                    @(Model.PressProofQty ?? 1) × @FormatCurrency(Model.PressProofPrice.Value) @(Model.PressProofUnit ?? "each")
-                                </small>
-                            </td>
-                            <td></td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(totalPressProofPrice)</td>
-                            <td style="font-weight: 600;">total</td>
-                        </tr>
-                    }
-
-                    @if (Model.QuoteRequest?.NeedsSpotColorPlateChange == true && Model.SpotColorPlateChangePrice.HasValue)
-                    {
-                        var totalPlateChangePrice = Model.SpotColorPlateChangePrice.Value * (Model.SpotColorPlateChangeQty ?? 1);
-                        <tr style="background: #fef9c3;">
-                            <td style="font-weight: 600;">
-                                <span style="color: #854d0e;">🎨</span> Spot Color Plate/Copy Change
-                                <br />
-                                <small style="color: #713f12; font-weight: normal;">
-                                    @(Model.SpotColorPlateChangeQty ?? 1) × @FormatCurrency(Model.SpotColorPlateChangePrice.Value) @(Model.SpotColorPlateChangeUnit ?? "each")
-                                </small>
-                            </td>
-                            <td></td>
-                            <td class="text-right" style="font-weight: 600;">@FormatCurrency(totalPlateChangePrice)</td>
-                            <td style="font-weight: 600;">total</td>
-                        </tr>
-                    }
-
-                    @if (!hasAnyCharges)
-                    {
-                        <tr>
-                            <td colspan="4" style="text-align:center; color:#94a3b8; font-style:italic;">
-                                No additional charges were added to this quote.
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
-        </section>
+        @await Html.PartialAsync("_AdditionalCharges", (IReadOnlyList<WiseLabels.Models.QuoteLineItem>)(Model.QuoteRequest?.LineItems ?? new List<WiseLabels.Models.QuoteLineItem>()))
 
         <section class="notes">
             <strong>Notes & Next Steps</strong>

--- a/Pages/Success.cshtml.cs
+++ b/Pages/Success.cshtml.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using WiseLabels.Models;
 using WiseLabels.Services;
@@ -45,20 +45,6 @@ namespace WiseLabels.Pages
         public bool EmailSent { get; set; }
         public QuoteRequest? QuoteRequest { get; set; }
         public DateTime SubmittedDate { get; set; } = DateTime.UtcNow;
-        public decimal? CustomDiePrice { get; set; }
-        public string? CustomDieUnit { get; set; }
-        public decimal? ColorChangesPrice { get; set; }
-        public string? ColorChangesUnit { get; set; }
-        public int? ColorChangesQty { get; set; }
-        public decimal? DigitalVersionChangesPrice { get; set; }
-        public string? DigitalVersionChangesUnit { get; set; }
-        public int? DigitalVersionChangesQty { get; set; }
-        public decimal? PressProofPrice { get; set; }
-        public string? PressProofUnit { get; set; }
-        public int? PressProofQty { get; set; }
-        public decimal? SpotColorPlateChangePrice { get; set; }
-        public string? SpotColorPlateChangeUnit { get; set; }
-        public int? SpotColorPlateChangeQty { get; set; }
         /// <summary>Submitted date/time in Eastern Time for display.</summary>
         public DateTime SubmittedDateEastern =>
             TimeZoneInfo.ConvertTimeFromUtc(
@@ -96,65 +82,14 @@ namespace WiseLabels.Pages
                 EmailSent = emailSent;
             }
 
-            // Load custom die price and unit
-            if (decimal.TryParse(TempData["CustomDiePrice"]?.ToString(), out var customDiePrice))
-            {
-                CustomDiePrice = customDiePrice;
-            }
-
-            CustomDieUnit = TempData["CustomDieUnit"]?.ToString();
-
-            // Load color changes price and quantity
-            if (decimal.TryParse(TempData["ColorChangesPrice"]?.ToString(), out var colorChangesPrice))
-            {
-                ColorChangesPrice = colorChangesPrice;
-            }
-            ColorChangesUnit = TempData["ColorChangesUnit"]?.ToString();
-            if (int.TryParse(TempData["ColorChangesQty"]?.ToString(), out var colorChangesQty))
-            {
-                ColorChangesQty = colorChangesQty;
-            }
-
-            // Load digital version changes price and quantity
-            if (decimal.TryParse(TempData["DigitalVersionChangesPrice"]?.ToString(), out var digitalVersionChangesPrice))
-            {
-                DigitalVersionChangesPrice = digitalVersionChangesPrice;
-            }
-            DigitalVersionChangesUnit = TempData["DigitalVersionChangesUnit"]?.ToString();
-            if (int.TryParse(TempData["DigitalVersionChangesQty"]?.ToString(), out var digitalVersionChangesQty))
-            {
-                DigitalVersionChangesQty = digitalVersionChangesQty;
-            }
-
-            // Load press proof price and quantity
-            if (decimal.TryParse(TempData["PressProofPrice"]?.ToString(), out var pressProofPrice))
-            {
-                PressProofPrice = pressProofPrice;
-            }
-            PressProofUnit = TempData["PressProofUnit"]?.ToString();
-            if (int.TryParse(TempData["PressProofQty"]?.ToString(), out var pressProofQty))
-            {
-                PressProofQty = pressProofQty;
-            }
-
-            // Load spot color plate change price and quantity
-            if (decimal.TryParse(TempData["SpotColorPlateChangePrice"]?.ToString(), out var spotColorPlateChangePrice))
-            {
-                SpotColorPlateChangePrice = spotColorPlateChangePrice;
-            }
-            SpotColorPlateChangeUnit = TempData["SpotColorPlateChangeUnit"]?.ToString();
-            if (int.TryParse(TempData["SpotColorPlateChangeQty"]?.ToString(), out var spotColorPlateChangeQty))
-            {
-                SpotColorPlateChangeQty = spotColorPlateChangeQty;
-            }
-
-            // Get quote request data for PDF generation
+            // Get quote request data for display and PDF generation
             if (TempData.TryGetValue("QuoteRequest", out var quoteData))
             {
                 try
                 {
                     var quoteJson = Convert.ToString(quoteData) ?? "{}";
                     QuoteRequest = JsonSerializer.Deserialize<QuoteRequest>(quoteJson);
+                    QuoteRequestCompat.UpgradeLegacyLineItems(QuoteRequest);
                     if (QuoteRequest != null && QuoteRequest.CreatedDate != default)
                     {
                         SubmittedDate = QuoteRequest.CreatedDate;

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-using CERM.DataAccess;
+﻿using CERM.DataAccess;
 using DinkToPdf;
 using DinkToPdf.Contracts;
 using System.Runtime.InteropServices;
@@ -36,6 +36,7 @@ builder.Services
 
 builder.Services.Configure<AccessControlOptions>(builder.Configuration.GetSection("Authorization"));
 builder.Services.Configure<WiseLabels.Configuration.UserFilteringOptions>(builder.Configuration.GetSection("UserFiltering"));
+builder.Services.Configure<WiseLabels.Configuration.LineItemOptions>(builder.Configuration.GetSection(WiseLabels.Configuration.LineItemOptions.SectionName));
 builder.Services.AddSingleton<IAuthorizationHandler, GroupAccessHandler>();
 builder.Services.AddAuthorization(options =>
 {
@@ -53,6 +54,11 @@ builder.Services.AddAuthorization(options =>
 });
 
 builder.Services.AddRazorPages()
+    // Session-backed TempData. The default CookieTempDataProvider Base64s the whole
+    // serialized QuoteRequest (including QuickQuoteResponseJson) into response cookies
+    // on every GetQuote -> Confirm -> Success hop, which pushes against Kestrel's
+    // 32 KB header limit once line items are added.
+    .AddSessionStateTempDataProvider()
     .AddMicrosoftIdentityUI();
 builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
@@ -70,10 +76,11 @@ builder.Services.AddScoped<WiseLabels.Services.ICermAuthService, WiseLabels.Serv
 builder.Services.AddScoped<WiseLabels.Services.IChatService, WiseLabels.Services.ChatService>();
 builder.Services.AddScoped<WiseLabels.Services.ICustomerContactService, WiseLabels.Services.CustomerContactService>();
 builder.Services.AddScoped<WiseLabels.Services.IUserImpersonationService, WiseLabels.Services.UserImpersonationService>();
-builder.Services.AddDbContext<CermDbContext>(options =>
-options.UseSqlServer(
-    builder.Configuration.GetConnectionString("CermDatabase"),
-    sql => sql.UseCompatibilityLevel(120)));
+builder.Services.AddScoped<WiseLabels.Services.ILineItemCatalogService, WiseLabels.Services.LineItemCatalogService>();
+// NOTE: CermDbContext is registered by AddCermDataAccessEF below (which also applies
+// UseCompatibilityLevel(120) and EnableRetryOnFailure). Do not re-register it here -
+// AddDbContext uses TryAdd, so a duplicate registration silently discards the other
+// one's options.
 builder.Services.AddScoped<CERM.DataAccess.Repositories.Job.IJobRepository, CERM.DataAccess.Repositories.Job.JobRepositoryEF>();
 builder.Services.AddScoped<CERM.DataAccess.Repositories.Substrate.ISubstrateRepository, CERM.DataAccess.Repositories.Substrate.SubstrateRepositoryEF>();
 

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -1,5 +1,6 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.Mail;
 using System.Text;
@@ -332,6 +333,7 @@ pre {{ margin: 0; white-space: pre-wrap; word-wrap: break-word; font-size: 11px;
             var contactTable = BuildDefinitionTable(GetContactRows(quote));
             var detailTable = BuildDefinitionTable(GetDetailRows(quote));
             var pricingTable = BuildPricingTable(priceBreakdown);
+            var chargesTable = BuildAdditionalChargesTable(quote.LineItems);
 
             var sb = new StringBuilder();
             sb.Append("""
@@ -385,6 +387,11 @@ pre {{ margin: 0; white-space: pre-wrap; word-wrap: break-word; font-size: 11px;
             if (!string.IsNullOrEmpty(detailTable))
             {
                 sb.Append(@"<div class=""section""><h3>Quote Details</h3>" + detailTable + "</div>");
+            }
+
+            if (!string.IsNullOrEmpty(chargesTable))
+            {
+                sb.Append(@"<div class=""section""><h3>Additional Charges</h3>" + chargesTable + "</div>");
             }
 
             if (!string.IsNullOrEmpty(pricingTable))
@@ -469,6 +476,65 @@ pre {{ margin: 0; white-space: pre-wrap; word-wrap: break-word; font-size: 11px;
                   .Append("<td>").Append(WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(price.Currency) ? "USD" : price.Currency)).Append("</td>")
                   .Append("</tr>");
             }
+
+            sb.Append("</tbody></table>");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Renders the selected line item charges. Shares
+        /// <see cref="LineItemPricing.Total"/> with the Confirm and Success pages, so the
+        /// emailed total cannot disagree with what the customer saw on screen.
+        /// </summary>
+        private static string BuildAdditionalChargesTable(IReadOnlyList<QuoteLineItem>? lineItems)
+        {
+            var charges = (lineItems ?? new List<QuoteLineItem>())
+                .Where(i => i.Selected)
+                .OrderBy(i => i.Order)
+                .ToList();
+
+            if (charges.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("""
+<table class="price-table" cellspacing="0" cellpadding="0">
+    <thead>
+        <tr>
+            <th>Description</th>
+            <th>Quantity</th>
+            <th>Unit Price</th>
+            <th>Total</th>
+        </tr>
+    </thead>
+    <tbody>
+""");
+
+            foreach (var charge in charges)
+            {
+                var description = WebUtility.HtmlEncode(charge.Description ?? string.Empty);
+                if (!string.IsNullOrWhiteSpace(charge.Description2))
+                {
+                    description += "<br />" + WebUtility.HtmlEncode(charge.Description2);
+                }
+
+                sb.Append("<tr>")
+                  .Append("<td>").Append(description).Append("</td>")
+                  .Append("<td>")
+                  .Append(LineItemPricing.IsQuantityBased(charge.PriceBasis)
+                      ? charge.Quantity.ToString("0.##", CultureInfo.CurrentCulture)
+                      : "-")
+                  .Append("</td>")
+                  .Append("<td>").Append(charge.UnitPrice.ToString("C2", CultureInfo.CurrentCulture)).Append("</td>")
+                  .Append("<td>").Append(charge.Total.ToString("C2", CultureInfo.CurrentCulture)).Append("</td>")
+                  .Append("</tr>");
+            }
+
+            sb.Append("<tr><td colspan=\"3\"><strong>Total additional charges</strong></td><td><strong>")
+              .Append(LineItemPricing.TotalOf(charges).ToString("C2", CultureInfo.CurrentCulture))
+              .Append("</strong></td></tr>");
 
             sb.Append("</tbody></table>");
             return sb.ToString();

--- a/Services/ILineItemCatalogService.cs
+++ b/Services/ILineItemCatalogService.cs
@@ -1,0 +1,52 @@
+using WiseLabels.Models;
+
+namespace WiseLabels.Services
+{
+    /// <summary>
+    /// Facts about a quote that decide which line items are offered and pre-ticked.
+    /// </summary>
+    /// <param name="CustomerId">CERM customer, used to pick customer-specific pricing.</param>
+    /// <param name="PrintingId">Selected printing/colour code ID (never the label text).</param>
+    /// <param name="ShapeValue">Selected shape value.</param>
+    /// <param name="CornersValue">Selected corners value.</param>
+    /// <param name="IsCustomDie">Whether dimension matching flagged a custom die.</param>
+    /// <param name="HasExistingDie">Whether the user picked an existing die from the list.</param>
+    public record LineItemContext(
+        string? CustomerId = null,
+        string? PrintingId = null,
+        string? ShapeValue = null,
+        string? CornersValue = null,
+        bool IsCustomDie = false,
+        bool HasExistingDie = false);
+
+    /// <summary>
+    /// Loads the selectable charge catalogue for a quote from the CERM standard price
+    /// list, applies the configured labelling and applicability rules, and merges in any
+    /// selections already made on the quote.
+    /// </summary>
+    public interface ILineItemCatalogService
+    {
+        /// <summary>
+        /// Builds the catalogue for a quote. Never throws: a database failure yields an
+        /// empty catalogue so the quote stays submittable, matching prior behaviour.
+        /// </summary>
+        /// <param name="context">Quote facts used to evaluate the rules.</param>
+        /// <param name="existing">Selections already made, merged in by item ref/key.</param>
+        Task<IReadOnlyList<QuoteLineItem>> GetCatalogAsync(
+            LineItemContext context,
+            IEnumerable<QuoteLineItem>? existing = null);
+
+        /// <summary>
+        /// Re-resolves posted line items against the catalogue: descriptions, units,
+        /// prices and price bases come from CERM, and only selection and quantity are
+        /// taken from the caller. Posted items with no catalogue match are dropped.
+        /// </summary>
+        /// <remarks>
+        /// This is the trust boundary. The quote form is user-editable, so a posted
+        /// price must never be believed.
+        /// </remarks>
+        Task<List<QuoteLineItem>> ResolvePostedAsync(
+            LineItemContext context,
+            IEnumerable<QuoteLineItem>? posted);
+    }
+}

--- a/Services/LineItemCatalogService.cs
+++ b/Services/LineItemCatalogService.cs
@@ -61,13 +61,17 @@ namespace WiseLabels.Services
                 _options.Items.Select(i => i.ItemRef ?? string.Empty), StringComparer.OrdinalIgnoreCase);
 
             var nextOrder = catalog.Count == 0 ? 0 : catalog.Max(i => i.Order);
-            foreach (var row in priceRows.Values)
-            {
-                if (configuredRefs.Contains(row.ItemRef?.Trim() ?? string.Empty)) continue;
+            var prioritized = priceRows.Values
+                .Where(r => !configuredRefs.Contains(r.ItemRef?.Trim() ?? string.Empty))
+                .OrderBy(r => (r.Priority ?? string.Empty).Trim(), StringComparer.Ordinal)
+                .ThenBy(r => r.ItemRef, StringComparer.Ordinal);
 
+            foreach (var row in prioritized)
+            {
                 var item = Project(row, definition: null);
                 if (item == null) continue;
 
+                // Sorted behind the configured entries, in Priority order.
                 item.Order = ++nextOrder + 1000;
                 catalog.Add(item);
             }
@@ -174,10 +178,10 @@ namespace WiseLabels.Services
                     }
                 }
 
-                if (!string.IsNullOrWhiteSpace(_options.WebFlagValue))
+                if (_options.IncludePrioritizedItems)
                 {
                     foreach (var row in await _priceListRepository.GetWebQuoteItemsAsync(
-                                 _options.WebFlagValue, preferred, _options.StandardCustomerRef))
+                                 preferred, _options.StandardCustomerRef))
                     {
                         rows.TryAdd(row.ItemRef?.Trim() ?? string.Empty, row);
                     }

--- a/Services/LineItemCatalogService.cs
+++ b/Services/LineItemCatalogService.cs
@@ -1,0 +1,326 @@
+using CERM.DataAccess.Models;
+using CERM.DataAccess.Repositories.PriceList;
+using Microsoft.Extensions.Options;
+using WiseLabels.Configuration;
+using WiseLabels.Models;
+
+namespace WiseLabels.Services
+{
+    /// <inheritdoc cref="ILineItemCatalogService"/>
+    public class LineItemCatalogService : ILineItemCatalogService
+    {
+        private readonly IPriceListItemRepository _priceListRepository;
+        private readonly LineItemOptions _options;
+        private readonly ILogger<LineItemCatalogService> _logger;
+
+        /// <summary>Creates the service.</summary>
+        public LineItemCatalogService(
+            IPriceListItemRepository priceListRepository,
+            IOptions<LineItemOptions> options,
+            ILogger<LineItemCatalogService> logger)
+        {
+            _priceListRepository = priceListRepository;
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<QuoteLineItem>> GetCatalogAsync(
+            LineItemContext context,
+            IEnumerable<QuoteLineItem>? existing = null)
+        {
+            var priceRows = await LoadPriceRowsAsync(context.CustomerId);
+            var catalog = new List<QuoteLineItem>();
+
+            // 1. Configured entries, in configured order.
+            foreach (var definition in _options.Items.OrderBy(i => i.Order))
+            {
+                if (!priceRows.TryGetValue(definition.ItemRef ?? string.Empty, out var row))
+                {
+                    _logger.LogWarning(
+                        "Line item {Key} is configured with item ref {ItemRef} but no active row was found in stdfpl__; it will not be offered.",
+                        definition.Key, definition.ItemRef);
+                    continue;
+                }
+
+                var item = Project(row, definition);
+                if (item == null) continue;
+
+                if (!Matches(definition.OfferWhen, context, offeredByDefault: true)) continue;
+
+                item.Forced = Matches(definition.ForceWhen, context, offeredByDefault: false);
+                item.Selected = item.Forced || Matches(definition.AutoSelectWhen, context, offeredByDefault: false);
+                if (item.Forced) item.QuantityEditable = definition.QuantityEditable;
+
+                catalog.Add(item);
+            }
+
+            // 2. Anything else the CERM price list flags for the web quote, so the
+            //    catalogue can be extended from CERM without a code change.
+            var configuredRefs = new HashSet<string>(
+                _options.Items.Select(i => i.ItemRef ?? string.Empty), StringComparer.OrdinalIgnoreCase);
+
+            var nextOrder = catalog.Count == 0 ? 0 : catalog.Max(i => i.Order);
+            foreach (var row in priceRows.Values)
+            {
+                if (configuredRefs.Contains(row.ItemRef?.Trim() ?? string.Empty)) continue;
+
+                var item = Project(row, definition: null);
+                if (item == null) continue;
+
+                item.Order = ++nextOrder + 1000;
+                catalog.Add(item);
+            }
+
+            MergeExisting(catalog, existing);
+            return catalog;
+        }
+
+        /// <inheritdoc />
+        public async Task<List<QuoteLineItem>> ResolvePostedAsync(
+            LineItemContext context,
+            IEnumerable<QuoteLineItem>? posted)
+        {
+            var catalog = await GetCatalogAsync(context);
+            if (catalog.Count == 0) return new List<QuoteLineItem>();
+
+            var postedList = posted?.ToList() ?? new List<QuoteLineItem>();
+            var resolved = new List<QuoteLineItem>();
+
+            foreach (var item in catalog)
+            {
+                var match = postedList.FirstOrDefault(p => IsSameItem(p, item));
+
+                // Only selection and quantity are ever taken from the client. Everything
+                // that affects price comes back from CERM.
+                if (match != null)
+                {
+                    item.Selected = match.Selected;
+                    if (item.QuantityEditable)
+                    {
+                        item.Quantity = ClampQuantity(match.Quantity);
+                    }
+                    if (match.Selected && !Matches(FindDefinition(item.Key)?.AutoSelectWhen, context, false))
+                    {
+                        item.Source = LineItemSource.Manual;
+                    }
+                }
+
+                // A forced item stays selected regardless of what was posted.
+                if (item.Forced) item.Selected = true;
+
+                if (item.Selected) resolved.Add(item);
+            }
+
+            var dropped = postedList.Count(p => !catalog.Any(c => IsSameItem(p, c)));
+            if (dropped > 0)
+            {
+                _logger.LogWarning("Dropped {Count} posted line item(s) with no catalogue match.", dropped);
+            }
+
+            return resolved;
+        }
+
+        private LineItemDefinition? FindDefinition(string? key) =>
+            string.IsNullOrWhiteSpace(key)
+                ? null
+                : _options.Items.FirstOrDefault(i => string.Equals(i.Key, key, StringComparison.OrdinalIgnoreCase));
+
+        private static bool IsSameItem(QuoteLineItem a, QuoteLineItem b) =>
+            (!string.IsNullOrWhiteSpace(a.ItemRef) && string.Equals(a.ItemRef, b.ItemRef, StringComparison.OrdinalIgnoreCase))
+            || (!string.IsNullOrWhiteSpace(a.Key) && string.Equals(a.Key, b.Key, StringComparison.OrdinalIgnoreCase));
+
+        private decimal ClampQuantity(decimal quantity)
+        {
+            if (quantity < 0) return 0;
+            var max = _options.MaxQuantity > 0 ? _options.MaxQuantity : 9999;
+            return quantity > max ? max : decimal.Truncate(quantity);
+        }
+
+        private static void MergeExisting(List<QuoteLineItem> catalog, IEnumerable<QuoteLineItem>? existing)
+        {
+            if (existing == null) return;
+            foreach (var saved in existing)
+            {
+                var target = catalog.FirstOrDefault(c => IsSameItem(saved, c));
+                if (target == null) continue;
+                target.Selected = saved.Selected || target.Forced;
+                if (target.QuantityEditable && saved.Quantity > 0)
+                {
+                    target.Quantity = saved.Quantity;
+                }
+                if (saved.Source == LineItemSource.Manual) target.Source = LineItemSource.Manual;
+            }
+        }
+
+        private async Task<Dictionary<string, PriceListItem>> LoadPriceRowsAsync(string? customerId)
+        {
+            var rows = new Dictionary<string, PriceListItem>(StringComparer.OrdinalIgnoreCase);
+            var preferred = _options.PreferCustomerPricing ? customerId : null;
+
+            try
+            {
+                var configuredRefs = _options.Items
+                    .Select(i => i.ItemRef)
+                    .Where(r => !string.IsNullOrWhiteSpace(r))
+                    .ToList()!;
+
+                if (configuredRefs.Count > 0)
+                {
+                    foreach (var row in await _priceListRepository.GetActiveByItemRefsAsync(
+                                 configuredRefs!, preferred, _options.StandardCustomerRef))
+                    {
+                        rows[row.ItemRef?.Trim() ?? string.Empty] = row;
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(_options.WebFlagValue))
+                {
+                    foreach (var row in await _priceListRepository.GetWebQuoteItemsAsync(
+                                 _options.WebFlagValue, preferred, _options.StandardCustomerRef))
+                    {
+                        rows.TryAdd(row.ItemRef?.Trim() ?? string.Empty, row);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // A pricing outage must not block a quote. Prior behaviour was to log and
+                // render no charges; keep that.
+                _logger.LogError(ex, "Failed to load the line item price list; the quote will be offered without charges.");
+                return new Dictionary<string, PriceListItem>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// Projects a CERM price list row into a quote line item, selecting the language
+        /// columns and rejecting price bases this application cannot price.
+        /// </summary>
+        private QuoteLineItem? Project(PriceListItem row, LineItemDefinition? definition)
+        {
+            var basis = (row.PriceType ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(basis)) basis = LineItemPricing.PerPiece;
+
+            if (!LineItemPricing.IsSupportedBasis(basis))
+            {
+                _logger.LogWarning(
+                    "Line item {ItemRef} has price basis '{Basis}', which this application cannot price; it will not be offered.",
+                    row.ItemRef, basis);
+                return null;
+            }
+
+            var line1 = SelectLanguage(row, lineNumber: 1);
+            var line2 = SelectLanguage(row, lineNumber: 2);
+            var unit = SelectUnit(row);
+
+            var quantityEditable = definition?.QuantityEditable ?? true;
+            if (!LineItemPricing.IsQuantityBased(basis)) quantityEditable = false;
+
+            var defaultQuantity = definition?.DefaultQuantity ?? 1;
+            if (defaultQuantity <= 0) defaultQuantity = 1;
+
+            return new QuoteLineItem
+            {
+                ItemRef = row.ItemRef?.Trim() ?? string.Empty,
+                CustomerRef = row.CustomerRef?.Trim(),
+                Key = definition?.Key ?? row.ItemRef?.Trim() ?? string.Empty,
+                Description = !string.IsNullOrWhiteSpace(definition?.Label) ? definition!.Label! : line1,
+                Description2 = line2,
+                Unit = string.IsNullOrWhiteSpace(unit) ? LineItemPricing.BasisLabel(basis) : unit,
+                UnitPrice = (decimal)row.PriceExcludingTax,
+                Quantity = defaultQuantity,
+                QuantityEditable = quantityEditable,
+                PriceBasis = basis,
+                Currency = string.IsNullOrWhiteSpace(row.CurrencyRef) ? null : row.CurrencyRef.Trim(),
+                Order = definition?.Order ?? 0,
+                Source = string.IsNullOrWhiteSpace(row.CustomerRef) ? LineItemSource.Rule : LineItemSource.Customer
+            };
+        }
+
+        /// <summary>
+        /// CERM stores descriptions as <c>fkttxt{line}{language}</c> - two LINES of one
+        /// description per language, joined with a newline on the quote letter. Reading
+        /// only <c>fkttxt11</c> silently drops the second line.
+        /// </summary>
+        private string SelectLanguage(PriceListItem row, int lineNumber)
+        {
+            var language = _options.LanguageIndex is >= 1 and <= 9 ? _options.LanguageIndex : 1;
+            var value = (lineNumber, language) switch
+            {
+                (1, 1) => row.InvoiceText11,
+                (1, 2) => row.InvoiceText12,
+                (1, 3) => row.InvoiceText13,
+                (2, 1) => row.InvoiceText21,
+                (2, 2) => row.InvoiceText22,
+                (2, 3) => row.InvoiceText23,
+                _ => lineNumber == 1 ? row.InvoiceText11 : row.InvoiceText21
+            };
+            return (value ?? string.Empty).Trim();
+        }
+
+        private string SelectUnit(PriceListItem row)
+        {
+            var language = _options.LanguageIndex is >= 1 and <= 9 ? _options.LanguageIndex : 1;
+            var value = language switch
+            {
+                1 => row.QuantityDescription1,
+                2 => row.QuantityDescription2,
+                3 => row.QuantityDescription3,
+                _ => row.QuantityDescription1
+            };
+            return (value ?? string.Empty).Trim();
+        }
+
+        /// <summary>
+        /// Evaluates a rule list. A list matches if ANY condition holds; an empty or
+        /// missing list falls back to <paramref name="offeredByDefault"/>, which is how
+        /// "always offered" is expressed.
+        /// </summary>
+        private static bool Matches(List<LineItemCondition>? conditions, LineItemContext context, bool offeredByDefault)
+        {
+            if (conditions == null || conditions.Count == 0) return offeredByDefault;
+            return conditions.Any(c => Matches(c, context));
+        }
+
+        private static bool Matches(LineItemCondition condition, LineItemContext context)
+        {
+            if (condition.PrintingIdIn is { Count: > 0 })
+            {
+                if (string.IsNullOrWhiteSpace(context.PrintingId)) return false;
+                if (!condition.PrintingIdIn.Any(p => string.Equals(p?.Trim(), context.PrintingId.Trim(), StringComparison.OrdinalIgnoreCase)))
+                    return false;
+            }
+
+            if (condition.PrintingIdPrefixIn is { Count: > 0 })
+            {
+                if (string.IsNullOrWhiteSpace(context.PrintingId)) return false;
+                if (!condition.PrintingIdPrefixIn.Any(p =>
+                        !string.IsNullOrWhiteSpace(p) &&
+                        context.PrintingId.Trim().StartsWith(p.Trim(), StringComparison.OrdinalIgnoreCase)))
+                    return false;
+            }
+
+            if (condition.ShapeIn is { Count: > 0 })
+            {
+                if (string.IsNullOrWhiteSpace(context.ShapeValue)) return false;
+                if (!condition.ShapeIn.Any(s => string.Equals(s?.Trim(), context.ShapeValue.Trim(), StringComparison.OrdinalIgnoreCase)))
+                    return false;
+            }
+
+            if (condition.CornersNotIn is { Count: > 0 })
+            {
+                var corners = context.CornersValue?.Trim() ?? string.Empty;
+                if (condition.CornersNotIn.Any(c => string.Equals(c?.Trim(), corners, StringComparison.OrdinalIgnoreCase)))
+                    return false;
+            }
+
+            if (condition.CustomDie.HasValue && condition.CustomDie.Value != context.IsCustomDie) return false;
+
+            if (condition.NoExistingDie.HasValue && condition.NoExistingDie.Value != !context.HasExistingDie) return false;
+
+            return true;
+        }
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "Admin": {
     "Password": ""
   },
@@ -16,7 +16,8 @@
     "ApiKey": "AIzaSyAzNpqNF-FXmb1CEZIeDMRtMnLkRvBp9Mg"
   },
   "ConnectionStrings": {
-    "CermDbConnection": "Server=CERM-DATA\\CRMDB;Database=sqlb00;user id=CermSys;password=SysCerm01.;TrustServerCertificate=True;"
+    "CermDbConnection": "Server=CERM-DATA\\CRMDB;Database=sqlb00;user id=CermSys;password=SysCerm01.;TrustServerCertificate=True;",
+    "CermDatabase": "Server=CERM-DATA\\CRMDB;Database=sqlb00;user id=CermSys;password=SysCerm01.;TrustServerCertificate=True;"
   },
   "Cerm": {
     "PackingProceduresUrl": "https://brandmark-api.cerm.be/parameter-api/v1/calculation/packing-procedures",
@@ -49,6 +50,52 @@
     ]
   },
   "QuoteOptions": {
+    "LineItems": {
+      "StandardCustomerRef": "",
+      "LanguageIndex": 1,
+      "PreferCustomerPricing": true,
+      "WebFlagValue": "",
+      "MaxQuantity": 9999,
+      "Items": [
+        {
+          "Key": "CustomDie",
+          "ItemRef": "100001",
+          "Label": "Custom Die Fabrication",
+          "Order": 10,
+          "DefaultQuantity": 1,
+          "QuantityEditable": false,
+          "ForceWhen": [ { "NoExistingDie": true } ]
+        },
+        {
+          "Key": "ColorChanges",
+          "ItemRef": "100018",
+          "Order": 20,
+          "DefaultQuantity": 1,
+          "QuantityEditable": true
+        },
+        {
+          "Key": "DigitalVersionChanges",
+          "ItemRef": "100035",
+          "Order": 30,
+          "DefaultQuantity": 1,
+          "QuantityEditable": true
+        },
+        {
+          "Key": "PressProof",
+          "ItemRef": "100031",
+          "Order": 40,
+          "DefaultQuantity": 1,
+          "QuantityEditable": true
+        },
+        {
+          "Key": "SpotColorPlateChange",
+          "ItemRef": "100017",
+          "Order": 50,
+          "DefaultQuantity": 1,
+          "QuantityEditable": true
+        }
+      ]
+    },
     "PrintingFinishFilters": {
       "spot-1-standard": [ "Flexo" ],
       "spot-2-standard": [ "Flexo" ],

--- a/appsettings.json
+++ b/appsettings.json
@@ -54,7 +54,7 @@
       "StandardCustomerRef": "",
       "LanguageIndex": 1,
       "PreferCustomerPricing": true,
-      "WebFlagValue": "",
+      "IncludePrioritizedItems": true,
       "MaxQuantity": 9999,
       "Items": [
         {

--- a/wwwroot/js/line-items.js
+++ b/wwwroot/js/line-items.js
@@ -1,0 +1,188 @@
+/*
+ * Quote line items grid.
+ *
+ * Behaviour deliberately differs from the charge fields this replaced:
+ *   - the section is never hidden, so every charge stays reachable regardless of
+ *     printing method (press proof used to be unreachable on black-only-digital);
+ *   - a printing change never clears what the user typed. Rules may re-tick rows the
+ *     user has not touched, and nothing more.
+ *
+ * The keepInSyncWithForm() serializer is the only writer of #line-items-json, which is
+ * what the server binds. Selection and quantity are the only values the server trusts;
+ * descriptions, prices and price bases are re-resolved from CERM on the way in.
+ */
+(function () {
+    'use strict';
+
+    // Mirrors WiseLabels.Models.LineItemPricing.Total. Keep the two in step.
+    var BASIS = {
+        TEXT: '0',
+        FIXED: '2',
+        PER_PIECE: '5',
+        PER_100: '6',
+        PER_1000: '7',
+        PER_100000: '8'
+    };
+
+    function total(basis, unitPrice, quantity) {
+        switch (String(basis || '').trim()) {
+            case BASIS.TEXT: return 0;
+            case BASIS.FIXED: return unitPrice;
+            case BASIS.PER_PIECE: return unitPrice * quantity;
+            case BASIS.PER_100: return unitPrice * quantity / 100;
+            case BASIS.PER_1000: return unitPrice * quantity / 1000;
+            case BASIS.PER_100000: return unitPrice * quantity / 100000;
+            default: return 0;
+        }
+    }
+
+    function money(value) {
+        return value.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+    }
+
+    function rows() {
+        return Array.prototype.slice.call(document.querySelectorAll('.line-item-row'));
+    }
+
+    function readRow(row) {
+        var checkbox = row.querySelector('.line-item-selected');
+        var qtyInput = row.querySelector('.line-item-qty');
+        var quantity = parseFloat(qtyInput && qtyInput.value);
+        if (!isFinite(quantity) || quantity < 0) quantity = 0;
+        return {
+            itemRef: row.dataset.itemRef || '',
+            key: row.dataset.key || '',
+            priceBasis: row.dataset.priceBasis || BASIS.PER_PIECE,
+            unitPrice: parseFloat(row.dataset.unitPrice) || 0,
+            forced: row.dataset.forced === 'true',
+            selected: row.dataset.forced === 'true' || !!(checkbox && checkbox.checked),
+            quantity: quantity
+        };
+    }
+
+    function repaint() {
+        var grand = 0;
+        rows().forEach(function (row) {
+            var data = readRow(row);
+            var lineTotal = total(data.priceBasis, data.unitPrice, data.quantity);
+            var cell = row.querySelector('.line-item-total');
+            if (cell) cell.textContent = money(lineTotal);
+            row.classList.toggle('table-active', data.selected);
+            if (data.selected) grand += lineTotal;
+        });
+        var totalCell = document.getElementById('line-items-total');
+        if (totalCell) totalCell.textContent = money(grand);
+        serialize();
+    }
+
+    function serialize() {
+        var field = document.getElementById('line-items-json');
+        if (!field) return;
+        field.value = JSON.stringify(rows().map(function (row) {
+            var data = readRow(row);
+            // Only what the server trusts. Prices are re-resolved server-side.
+            return {
+                itemRef: data.itemRef,
+                key: data.key,
+                selected: data.selected,
+                quantity: data.quantity
+            };
+        }));
+    }
+
+    /**
+     * Re-evaluates which rows should be pre-ticked after a spec change, without ever
+     * discarding a row the user has touched.
+     */
+    function applyRules(context) {
+        rows().forEach(function (row) {
+            if (row.dataset.userTouched === 'true') return;
+            var checkbox = row.querySelector('.line-item-selected');
+            if (!checkbox || checkbox.disabled) return;
+
+            var autoSelect = row.dataset.autoSelectPrintingIds;
+            if (!autoSelect) return;
+
+            var ids = autoSelect.split(',').map(function (s) { return s.trim().toLowerCase(); });
+            var printingId = String((context && context.printingId) || '').trim().toLowerCase();
+            checkbox.checked = printingId !== '' && ids.indexOf(printingId) !== -1;
+        });
+        repaint();
+    }
+
+    /**
+     * The die charge is mandatory whenever no existing die size was chosen. This is the
+     * billing trigger; it replaces the dimension-matching heuristic, which never fired
+     * on the circle/diameter path and so never charged for circular custom dies.
+     */
+    function applyDieRule(hasExistingDie) {
+        rows().forEach(function (row) {
+            if (row.dataset.key !== 'CustomDie') return;
+            var checkbox = row.querySelector('.line-item-selected');
+            if (!checkbox) return;
+            var forced = !hasExistingDie;
+            row.dataset.forced = forced ? 'true' : 'false';
+            checkbox.disabled = forced;
+            if (forced) checkbox.checked = true;
+        });
+        repaint();
+    }
+
+    function init() {
+        if (!document.getElementById('line-items-section')) return;
+
+        rows().forEach(function (row) {
+            var checkbox = row.querySelector('.line-item-selected');
+            var qtyInput = row.querySelector('.line-item-qty');
+
+            if (checkbox) {
+                checkbox.addEventListener('change', function () {
+                    row.dataset.userTouched = 'true';
+                    repaint();
+                });
+            }
+            if (qtyInput) {
+                ['input', 'change'].forEach(function (evt) {
+                    qtyInput.addEventListener(evt, function () {
+                        row.dataset.userTouched = 'true';
+                        // Ticking follows a quantity the user actually entered.
+                        if (checkbox && !checkbox.disabled) {
+                            var qty = parseFloat(qtyInput.value);
+                            if (isFinite(qty) && qty > 0) checkbox.checked = true;
+                        }
+                        repaint();
+                    });
+                });
+            }
+        });
+
+        // Rules key on the printing ID, never the label text. The quote form dispatches
+        // this on window with detail { id, label, key, slug }.
+        window.addEventListener('printingSelectionChanged', function (event) {
+            applyRules({ printingId: event.detail && event.detail.id });
+        });
+
+        var existingDie = document.getElementById('existing-die-select');
+        if (existingDie) {
+            existingDie.addEventListener('change', function () {
+                applyDieRule(!!existingDie.value);
+            });
+            applyDieRule(!!existingDie.value);
+        }
+
+        // Serialize before submit so a quote posted without any interaction still carries
+        // its pre-ticked rows.
+        var form = document.getElementById('quote-form');
+        if (form) form.addEventListener('submit', serialize);
+
+        repaint();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    window.WiseLineItems = { repaint: repaint, applyRules: applyRules, applyDieRule: applyDieRule, total: total };
+})();


### PR DESCRIPTION
## Summary

Replaces the hardcoded charge fields (ColorChanges, DigitalVersionChanges, NeedsPressProof, NeedsSpotColorPlateChange) with a flexible, rule-driven line items catalogue sourced from the CERM price list. Charges are now proposed automatically based on quote context (printing method, shape, die requirements) and can be extended from CERM configuration without code changes.

## Key Changes

- **New configuration model** (`LineItemOptions`, `LineItemDefinition`, `LineItemCondition`) — defines which CERM price list rows are offered, when they are pre-ticked or mandatory, and how they are labeled
- **New service** (`ILineItemCatalogService`, `LineItemCatalogService`) — loads the price list, evaluates applicability rules, and merges user selections with server-side pricing
- **New data models** (`QuoteLineItem`, `LineItemPricing`, `LineItemSource`) — represents a selectable charge with pricing basis, quantity, and selection state
- **Compatibility shim** (`QuoteRequestCompat`) — upgrades legacy quote serializations (from TempData/session) that carry the old scalar fields into the new `LineItems` collection
- **New UI components**:
  - `_LineItemsEditor.cshtml` — renders the charge grid with checkboxes and quantity inputs
  - `_AdditionalCharges.cshtml` — shared renderer for Confirm, Success, and email confirmation pages (ensures all three surfaces agree on what was quoted)
  - `line-items.js` — client-side grid behavior: recalculates totals, serializes to JSON, respects forced/read-only rows
- **New API endpoint** (`Pages/Api/LineItems.cshtml.cs`) — returns the catalogue for a given quote context (printing ID, shape, etc.)
- **Updated pages**:
  - `GetQuote.cshtml.cs` — loads catalogue on form load and after printing/shape changes
  - `Confirm.cshtml.cs` / `Success.cshtml.cs` — removed hardcoded charge logic, now use `_AdditionalCharges.cshtml` partial
  - `EmailService.cs` — renders charges in confirmation email via the same partial
- **Configuration** (`appsettings.json`) — added `QuoteOptions:LineItems` section with example entries (PressProof, SpotColorPlateChange, ColorChanges, DigitalVersionChanges)

## Implementation Details

- **Price basis arithmetic** is centralized in `LineItemPricing.Total()` (mirrors client-side calculation in `line-items.js`) — supports Text, Fixed, Per-Piece, Per-100, Per-1000, Per-100000
- **Applicability rules** match on printing ID (exact or prefix), shape, corners, and custom-die/existing-die flags — never on label text (prevents breakage when labels are reworded)
- **Selection state** is preserved across form edits: forced items stay selected, auto-selected items stay selected unless the user unticks them, manual selections are tracked
- **Only selection and quantity** are trusted from the posted form; descriptions, prices, and price bases are always re-resolved from CERM
- **Catalogue is extensible**: configured entries appear first (in configured order), then any additional rows the CERM price list flags for web display (order 1000+)
- **Backward compatibility**: quotes in flight (TempData) or in session (30-minute lifetime) that carry the old scalar fields are automatically upgraded on load

## Migration Notes

The old charge properties (`ColorChanges`, `DigitalVersionChanges`, `NeedsPressProof`, `NeedsSpotColorPlateChange`) remain in `QuoteRequest.Extra` for one release to support in-flight quotes. They are removed from the main model and replaced by `LineItems`. The compatibility shim can be deleted one release after this ships.

https://claude.ai/code/session_017SQescJRUQLYY9ToKqJecu